### PR TITLE
[2022/11/02] design/relayProfileViewControllerStyleGuide >> RelayProfileViewController 색상/폰트/레이아웃을 스타일가이드에 맞게 수정

### DIFF
--- a/Relay/Relay/ProfileView/RelayProfileViewController.swift
+++ b/Relay/Relay/ProfileView/RelayProfileViewController.swift
@@ -17,7 +17,7 @@ class RelayProfileViewController: UIViewController {
     
     private lazy var separatorView: UIView = {
         let view = UIView()
-        view.backgroundColor = .black
+        view.backgroundColor = UIColor(red: 226/255, green: 226/255, blue: 226/255, alpha: 1.0)
         
         return view
     }()

--- a/Relay/Relay/ProfileView/Views/RelayNonLoginView.swift
+++ b/Relay/Relay/ProfileView/Views/RelayNonLoginView.swift
@@ -23,7 +23,8 @@ class RelayNonLoginView: UIView {
 로그인하지 않은 상태입니다.
 로그인/회원가입 후 이용해주세요.
 """
-        label.font = .systemFont(ofSize: 15.0)
+        label.setFont(.caption1)
+        label.textColor = UIColor(red: 114/255, green: 113/255, blue: 111/255, alpha: 1.0)
         label.numberOfLines = 2
         label.setLineHeight(text: text, lineHeight: 24.0)
         label.textAlignment = .center

--- a/Relay/Relay/ProfileView/Views/RelayNonLoginView.swift
+++ b/Relay/Relay/ProfileView/Views/RelayNonLoginView.swift
@@ -12,7 +12,7 @@ class RelayNonLoginView: UIView {
     private lazy var logoImageView: UIImageView = {
         let imageView = UIImageView()
         //TODO: backgroundColor를 Logo Image로 변경필요
-        imageView.backgroundColor = .blue
+        imageView.image = UIImage(named: "Lilla")
         
         return imageView
     }()

--- a/Relay/Relay/ProfileView/Views/RelayNonLoginView.swift
+++ b/Relay/Relay/ProfileView/Views/RelayNonLoginView.swift
@@ -40,7 +40,7 @@ class RelayNonLoginView: UIView {
         titleAttribute.foregroundColor = .white
         
         button.setAttributedTitle(NSAttributedString(titleAttribute), for: .normal)
-        button.backgroundColor = .black
+        button.backgroundColor = .relayPink1
         button.layer.cornerRadius = 12.0
         
         return button

--- a/Relay/Relay/ProfileView/Views/RelayNonLoginView.swift
+++ b/Relay/Relay/ProfileView/Views/RelayNonLoginView.swift
@@ -65,17 +65,17 @@ class RelayNonLoginView: UIView {
         logoImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(193.0)
             $0.centerX.equalToSuperview()
-            $0.width.equalTo(114.0)
-            $0.height.equalTo(123.0)
+            $0.width.equalTo(111.3)
+            $0.height.equalTo(120.0)
         }
         
         descriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(logoImageView.snp.bottom).offset(28.0)
+            $0.top.equalTo(logoImageView.snp.bottom).offset(30.0)
             $0.centerX.equalToSuperview()
         }
         
         loginButton.snp.makeConstraints {
-            $0.top.equalTo(descriptionLabel.snp.bottom).offset(24.0)
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(30.0)
             $0.leading.equalToSuperview().inset(20.0)
             $0.trailing.equalToSuperview().inset(20.0)
             $0.height.equalTo(56.0)

--- a/Relay/Relay/ProfileView/Views/RelayProfileUserActivityView.swift
+++ b/Relay/Relay/ProfileView/Views/RelayProfileUserActivityView.swift
@@ -11,8 +11,8 @@ import SnapKit
 class RelayProfileUserActivityView: UIView {
     private lazy var activityLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 20.0, weight: .bold)
         label.text = "나의 활동"
+        label.setFont(.body1)
         
         return label
     }()

--- a/Relay/Relay/ProfileView/Views/RelayProfileUserActivityView.swift
+++ b/Relay/Relay/ProfileView/Views/RelayProfileUserActivityView.swift
@@ -21,6 +21,8 @@ class RelayProfileUserActivityView: UIView {
         let layout = UICollectionViewFlowLayout()
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         
+        layout.minimumLineSpacing = 16.0
+        
         collectionView.delegate = self
         collectionView.dataSource = self
         collectionView.showsVerticalScrollIndicator = false
@@ -47,10 +49,6 @@ extension RelayProfileUserActivityView: UICollectionViewDelegateFlowLayout {
         let height = 100.0
         
         return CGSize(width: width, height: height)
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        UIEdgeInsets(top: 0.0, left: 0.0, bottom: 16.0, right: 0.0)
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {

--- a/Relay/Relay/ProfileView/Views/RelayProfileUserInfoView.swift
+++ b/Relay/Relay/ProfileView/Views/RelayProfileUserInfoView.swift
@@ -54,12 +54,7 @@ extension RelayProfileUserInfoView {
     }
     
     private func setUsersRelayCountLabel(_ startedRelayCount: Int, _ participatedRelayCount: Int) {
-        let textAttributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.systemFont(ofSize: 15.0)
-        ]
-        
         let numberAttributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.systemFont(ofSize: 15.0),
             .foregroundColor: UIColor.magenta
         ]
         
@@ -72,16 +67,13 @@ extension RelayProfileUserInfoView {
         let joinText = [startedStr, startedRelaysStr, dot, participatedStr, participatedRelaysStr].joined(separator: " ")
         let attributedString = NSMutableAttributedString(string: joinText)
         
-        let range1 = attributedString.mutableString.range(of: startedStr)
-        let range2 = attributedString.mutableString.range(of: startedRelaysStr)
-        let range3 = attributedString.mutableString.range(of: dot)
-        let range4 = attributedString.mutableString.range(of: participatedStr)
-        let range5 = attributedString.mutableString.range(of: participatedRelaysStr)
+        let range1 = attributedString.mutableString.range(of: startedRelaysStr)
+        let range2 = attributedString.mutableString.range(of: participatedRelaysStr)
         
-        [range1, range3, range4].forEach { attributedString.addAttributes(textAttributes, range: $0) }
-        [range2, range5].forEach { attributedString.addAttributes(numberAttributes, range: $0) }
+        [range1, range2].forEach { attributedString.addAttributes(numberAttributes, range: $0) }
         
         usersRelayCountLabel.attributedText = attributedString
+        usersRelayCountLabel.setFont(.caption1)
     }
     
     func configure() {

--- a/Relay/Relay/ProfileView/Views/RelayProfileUserInfoView.swift
+++ b/Relay/Relay/ProfileView/Views/RelayProfileUserInfoView.swift
@@ -55,7 +55,7 @@ extension RelayProfileUserInfoView {
     
     private func setUsersRelayCountLabel(_ startedRelayCount: Int, _ participatedRelayCount: Int) {
         let numberAttributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: UIColor.magenta
+            .foregroundColor: UIColor.relayPink1
         ]
         
         let startedStr = "시작한 릴레이"

--- a/Relay/Relay/ProfileView/Views/RelayUserActivityCollectionViewCell.swift
+++ b/Relay/Relay/ProfileView/Views/RelayUserActivityCollectionViewCell.swift
@@ -47,7 +47,7 @@ extension RelayUserActivityCollectionViewCell {
     
     private func setupLayout() {
         layer.cornerRadius = 16.0
-        backgroundColor = .systemGray6
+        backgroundColor = .relayGray2
         
         [
             imageView,

--- a/Relay/Relay/ProfileView/Views/RelayUserActivityCollectionViewCell.swift
+++ b/Relay/Relay/ProfileView/Views/RelayUserActivityCollectionViewCell.swift
@@ -82,7 +82,7 @@ extension RelayUserActivityCollectionViewCell {
     }
     
     private func setRelayActivityNumberLabel(_ relayCount: Int) {
-        let numberAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.magenta]
+        let numberAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.relayPink1]
         
         let countStr = "\(relayCount)"
         let postPosition = "개"

--- a/Relay/Relay/ProfileView/Views/RelayUserActivityCollectionViewCell.swift
+++ b/Relay/Relay/ProfileView/Views/RelayUserActivityCollectionViewCell.swift
@@ -22,7 +22,7 @@ final class RelayUserActivityCollectionViewCell: UICollectionViewCell {
     
     private lazy var relayActivityLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 16.0, weight: .bold)
+        label.setFont(.body1)
         
         return label
     }()
@@ -82,28 +82,19 @@ extension RelayUserActivityCollectionViewCell {
     }
     
     private func setRelayActivityNumberLabel(_ relayCount: Int) {
-        let textAttributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.systemFont(ofSize: 15.0)
-        ]
-        
-        let numberAttributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.systemFont(ofSize: 15.0),
-            .foregroundColor: UIColor.magenta
-        ]
+        let numberAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.magenta]
         
         let countStr = "\(relayCount)"
         let postPosition = "개"
         
         let joinText = [countStr, postPosition].joined(separator: "")
         let attributedString = NSMutableAttributedString(string: joinText)
-        
         let countRange = attributedString.mutableString.range(of: countStr)
-        let textRange = attributedString.mutableString.range(of: postPosition)
         
         attributedString.addAttributes(numberAttributes, range: countRange)
-        attributedString.addAttributes(textAttributes, range: textRange)
         
         relayActivityNumberLabel.attributedText = attributedString
+        relayActivityNumberLabel.setFont(.caption1)
     }
     
     private func setRelayActivityLabel(_ index: Int) {

--- a/Relay/Relay/ProfileView/Views/RelayUserActivityCollectionViewCell.swift
+++ b/Relay/Relay/ProfileView/Views/RelayUserActivityCollectionViewCell.swift
@@ -15,7 +15,7 @@ final class RelayUserActivityCollectionViewCell: UICollectionViewCell {
     
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.backgroundColor = .brown
+        imageView.image = UIImage(named: "Lilla")
         
         return imageView
     }()


### PR DESCRIPTION
## 작업사항
1. RelayProfileListCollectionView의 cell 사이 간격 수정
2. RelayProfileViewController 전체의 폰트/색상/레이아웃을 스타일가이드에 맞게 수정
3. Lilla 이미지 필요한 부분에 설정

|로그인 - 구현|로그인 - Figma|
|:---:|:---:|
|<img width="300" alt="로그인 피그마" src="https://user-images.githubusercontent.com/83946704/199570314-fad3d217-582b-4f45-8ac5-1e535597a45f.png">|<img width="300" alt="로그인 피그마" src="https://user-images.githubusercontent.com/83946704/199569532-1c90ee4a-284c-413c-8765-d38118e36bfd.png">|

|비로그인 - 구현|비로그인 - Figma|
|:---:|:---:|
|<img width="300" alt="로그인 피그마" src="https://user-images.githubusercontent.com/83946704/199569687-772ee3b5-ad71-4171-9cf1-212b6937b200.png">|<img width="300" alt="로그인 피그마" src="https://user-images.githubusercontent.com/83946704/199569704-4fbe6c57-0fc9-4bd1-904e-e6add62f8838.png">|

## 이슈번호
- #25 

## 특이사항(Optional)
1. RelayUserInfoView와 RelayUserActivityView 사이의 구분선 색상이 스타일가이드에 없어 피그마에 있는 색상으로 구현하였습니다.
2. 비로그인뷰의 descriptionLabel의 색상이 없어 피그마에 있는 색상으로 구현하였습니다.
3. commit 메세지의 태그가 25번 이슈로 잘못 커밋되어있습니다. 27번 이슈입니다.