### PR TITLE
[2022/11/03] design/relayListViewStyleGuide >> RelayListView의 색상/폰트를 스타일가이드에 맞게 수정

### DIFF
--- a/Relay/Relay/Reusable/RelayListView/RelayListCollectionViewCell.swift
+++ b/Relay/Relay/Reusable/RelayListView/RelayListCollectionViewCell.swift
@@ -15,11 +15,11 @@ class RelayListCollectionViewCell: UICollectionViewCell {
     
     private lazy var statusLabel: BasePaddingLabel = {
         let label = BasePaddingLabel()
-        label.font = .systemFont(ofSize: 13.0)
+        label.setFont(.caption2)
         label.textColor = .white
         
         label.clipsToBounds = true
-        label.backgroundColor = .systemPink
+        label.backgroundColor = .relayPink1
         label.layer.cornerRadius = 12.0
         
         return label
@@ -27,21 +27,21 @@ class RelayListCollectionViewCell: UICollectionViewCell {
     
     private lazy var stepCountLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 13.0)
+        label.setFont(.caption2)
         
         return label
     }()
     
     private lazy var relayTitleLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 17.0, weight: .bold)
+        label.setFont(.body1)
         
         return label
     }()
     
     private lazy var bgmTagLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 13.0)
+        label.setFont(.caption2)
         label.sizeToFit()
         
         return label
@@ -49,15 +49,16 @@ class RelayListCollectionViewCell: UICollectionViewCell {
     
     private lazy var creationTimeLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 13.0)
+        label.setFont(.caption2)
+        label.textColor = .relayGray
         
         return label
     }()
     
     private lazy var heartCountLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 13.0)
-        label.textColor = .systemPink
+        label.setFont(.caption2)
+        label.textColor = .relayPink1
         label.sizeToFit()
         
         return label
@@ -70,8 +71,8 @@ extension RelayListCollectionViewCell {
         
         if isCompleted {
             statusLabel.text = "완주"
-            statusLabel.textColor = .systemPink
-            statusLabel.layer.borderColor = UIColor.systemPink.cgColor
+            statusLabel.textColor = .relayPink1
+            statusLabel.layer.borderColor = UIColor.relayPink1.cgColor
             statusLabel.layer.borderWidth = 1.0
             statusLabel.backgroundColor = .systemBackground
         } else {
@@ -104,7 +105,7 @@ extension RelayListCollectionViewCell {
         let attributedString = NSMutableAttributedString(string: "")
         let imageAttachment = NSTextAttachment()
         imageAttachment.image = UIImage(systemName: "heart.fill") ?? UIImage()
-        imageAttachment.image = imageAttachment.image?.withTintColor(.systemPink)
+        imageAttachment.image = imageAttachment.image?.withTintColor(.relayPink1)
         imageAttachment.bounds = CGRect(x: 0.0, y: -3.0, width: 17.0, height: 14.0)
         
         attributedString.append(NSAttributedString(attachment: imageAttachment))
@@ -118,9 +119,9 @@ extension RelayListCollectionViewCell {
         bgmTagLabel.sizeToFit()
         
         if index == 0 {
-            layer.addBorder([.top, .bottom], color: .systemGray6, width: 1.0)
+            layer.addBorder([.top, .bottom], color: .relayGray2, width: 1.0)
         } else {
-            layer.addBorder([.bottom], color: .systemGray6, width: 1.0)
+            layer.addBorder([.bottom], color: .relayGray2, width: 1.0)
         }
     }
     

--- a/Relay/Relay/Reusable/RelayListView/RelayListHeaderView.swift
+++ b/Relay/Relay/Reusable/RelayListView/RelayListHeaderView.swift
@@ -25,7 +25,7 @@ class RelayListHeaderView: UIView {
     
     private lazy var listTitleLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 24.0, weight: .bold)
+        label.setFont(.display1)
         
         return label
     }()
@@ -80,6 +80,7 @@ class RelayListHeaderView: UIView {
     
     init(frame: CGRect, type: ViewType) {
         super.init(frame: frame)
+        backgroundColor = .systemBackground
         
         setupLayout(type)
     }


### PR DESCRIPTION
## 작업사항
RelayListView의 색상/폰트를 스타일가이드에 맞게 수정하였습니다.

|둘러보기(완주) - 구현|둘러보기(달리는중) - 구현|둘러보기 - Figma|
|:---:|:---:|:---:|
|<img width="300" alt="둘러보기 - Figma" src="https://user-images.githubusercontent.com/83946704/199661201-4baea76e-3541-419b-bd81-9db6d293895e.png">|<img width="300" alt="둘러보기 - Figma" src="https://user-images.githubusercontent.com/83946704/199661210-9809017e-8a29-4827-b907-e97ef7740606.png">|<img width="300" alt="둘러보기 - Figma" src="https://user-images.githubusercontent.com/83946704/199661220-889465ba-6141-4e71-9cba-768b1c790f2d.png">|

## 이슈번호
- #27 
