### PR TITLE
[2022.11.11] feat/relay setting view connecting >> 설정 뷰 연결

### DIFF
--- a/Relay/Relay/Scenes/DeleteAccountView/RelayDeleteAccountViewController.swift
+++ b/Relay/Relay/Scenes/DeleteAccountView/RelayDeleteAccountViewController.swift
@@ -36,7 +36,7 @@ extension RelayDeleteAccountViewController {
         ].forEach { view.addSubview($0) }
         
         userActivityView.snp.makeConstraints {
-            $0.top.equalToSuperview()
+            $0.top.equalToSuperview().inset(20.0)
             $0.leading.equalToSuperview()
             $0.trailing.equalToSuperview()
             $0.height.equalTo(510)

--- a/Relay/Relay/Scenes/SettingView/RelayMyInfoViewController.swift
+++ b/Relay/Relay/Scenes/SettingView/RelayMyInfoViewController.swift
@@ -47,7 +47,7 @@ class RelayMyInfoViewController: UIViewController, UITableViewDelegate, UITableV
                 //추후 로그아웃 알림창 구현
             },
             SettingsOption(title: "회원탈퇴", details: "", version: "") {
-                //추후 회원탈퇴뷰 연결
+                self.deleteAccountView()
             }
         ]))
     }
@@ -133,5 +133,15 @@ extension RelayMyInfoViewController {
         header.textLabel?.textColor = .systemBlue
         header.backgroundView = view
         
+    }
+}
+
+extension RelayMyInfoViewController {
+    @objc private func deleteAccountView(){
+        
+        let vc = RelayDeleteAccountViewController()
+        vc.title = "회원탈퇴"
+        
+        navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/Relay/Relay/Scenes/SettingView/RelayMyInfoViewController.swift
+++ b/Relay/Relay/Scenes/SettingView/RelayMyInfoViewController.swift
@@ -101,7 +101,7 @@ extension RelayMyInfoViewController {
         tableView.delegate = self
         tableView.dataSource = self
         tableView.frame = view.bounds
-        tableView.contentInset = .init(top: 100, left: 0, bottom: 0, right: 0) // 뷰 연결 시 top 값 조정필요
+        tableView.contentInset = .init(top: 0, left: 0, bottom: 0, right: 0)
         tableView.isScrollEnabled = false
         tableView.sectionHeaderHeight = 7
         tableView.sectionFooterHeight = 0

--- a/Relay/Relay/Scenes/SettingView/RelayPrivacyPolicyViewController.swift
+++ b/Relay/Relay/Scenes/SettingView/RelayPrivacyPolicyViewController.swift
@@ -89,7 +89,7 @@ extension RelayPrivacyPolicyViewController {
         ].forEach { view.addSubview($0) }
         
         scrollView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(80.0)
+            $0.top.equalToSuperview().inset(120.0)
             $0.leading.equalToSuperview().inset(20.0)
             $0.trailing.equalToSuperview().inset(20.0)
             $0.bottom.equalToSuperview().inset(20.0)

--- a/Relay/Relay/Scenes/SettingView/RelaySettingViewController.swift
+++ b/Relay/Relay/Scenes/SettingView/RelaySettingViewController.swift
@@ -43,7 +43,7 @@ class RelaySettingViewController: UIViewController, UITableViewDelegate, UITable
     func relaySettingViewConfigure() {
         models.append(Section(title: "", details: "", version: "", options: [
             SettingsOption(title: "내 정보", details: "Apple", version: "") {
-                //추후 RelayMyInfoViewController와 연결
+                self.toMyInfoView()
             },
             SettingsOption(title: "알림 설정", details: "", version: "") {
                 //추후 로컬 디바이스 알림설정과 연결
@@ -51,13 +51,13 @@ class RelaySettingViewController: UIViewController, UITableViewDelegate, UITable
         ]))
         models.append(Section(title: "", details: "", version: "", options: [
             SettingsOption(title: "릴레이에 대해서", details: "", version: "") {
-                //추후 RelayAboutRelayViewController와 연결
+                self.toAboutRelayView()
             },
             SettingsOption(title: "이용약관", details: "", version: "") {
-                //추후 이용약관 뷰 연결
+                self.toTermsAndConditionsView()
             },
             SettingsOption(title: "개인정보처리방침", details: "", version: "") {
-                //추후 개인정보처리방침 뷰 연결
+                self.toPrivacyPolicyView()
             },
             SettingsOption(title: "버전", details: "최신 버전입니다", version: "1.1.0") {
                 
@@ -137,7 +137,7 @@ extension RelaySettingViewController {
         tableView.delegate = self
         tableView.dataSource = self
         tableView.frame = view.bounds
-        tableView.contentInset = .init(top: 120, left: 0, bottom: 0, right: 0) // 뷰 연결 시 top 값 조정필요
+        tableView.contentInset = .init(top: 20, left: 0, bottom: 0, right: 0) 
         tableView.isScrollEnabled = false
         tableView.sectionHeaderHeight = 7
         tableView.sectionFooterHeight = 0
@@ -145,5 +145,32 @@ extension RelaySettingViewController {
         tableView.tableFooterView = UIView(frame: CGRect.zero)
         tableView.separatorColor = .relayGray2
         tableView.register(UITableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: "customHeader")
+    }
+}
+
+extension RelaySettingViewController {
+    @objc private func toMyInfoView(){
+        let vc = RelayMyInfoViewController()
+        vc.title = "내 정보"
+        
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    @objc private func toAboutRelayView(){
+        let vc = RelayAboutRelayViewController()
+        vc.title = "릴레이에 대해서"
+        
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    @objc private func toTermsAndConditionsView(){
+        let vc = RelayTermsAndConditionsViewController()
+        vc.title = "이용약관"
+        
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    @objc private func toPrivacyPolicyView(){
+        let vc = RelayPrivacyPolicyViewController()
+        vc.title = "개인정보 처리방침"
+        
+        navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/Relay/Relay/Scenes/SettingView/RelayTermsAndConditionsViewController.swift
+++ b/Relay/Relay/Scenes/SettingView/RelayTermsAndConditionsViewController.swift
@@ -244,7 +244,7 @@ extension RelayTermsAndConditionsViewController {
         ].forEach { view.addSubview($0) }
         
         scrollView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(80.0)
+            $0.top.equalToSuperview().inset(120.0)
             $0.leading.equalToSuperview().inset(20.0)
             $0.trailing.equalToSuperview().inset(20.0)
             $0.bottom.equalToSuperview().inset(20.0)


### PR DESCRIPTION
## 작업사항
- 내정보 뷰 연결
- 내정보 뷰 > 회원탈퇴 뷰 연결
- 릴레이에 대해서 뷰 연결
- 이용약관 뷰 연결
- 개인정보처리방침 뷰 연결
- 각 뷰 setupLayout 수정

## 이슈번호
- #59 

## 특이사항(Optional)
- '알림 설정'셀은 추후 로컬 디바이스 알림설정과 연결해야 합니다
- '굳굳 계정'셀은 추후 굳굳 sns 계정과 연결해야 합니다(or 셀 삭제) 
- 내정보 뷰 > '로그아웃' 셀은 추후 로그아웃 알러트창을 구현해야 합니다
- 릴레이에 대해서 뷰 > 튜토리얼 뷰(온보딩) 연결은 추후에 온보딩 로직 구현 후 할 예정입니다
- 네비게이션 바 커스텀 해야합니다

close #59 