### PR TITLE
[2022.11.11] feat/RelayMainViewController >>  메인뷰 카드 데이터 받을 수 있도록 안에 UI들 따로 설정

### DIFF
--- a/Relay/Relay.xcodeproj/project.pbxproj
+++ b/Relay/Relay.xcodeproj/project.pbxproj
@@ -42,7 +42,7 @@
 		55745FC2291A3BF100414462 /* BodyCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55745FC1291A3BF100414462 /* BodyCollectionViewCell.swift */; };
 		55745FC4291B7A5F00414462 /* RelayReadingWriteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55745FC3291B7A5F00414462 /* RelayReadingWriteView.swift */; };
 		55745FC6291B9B9F00414462 /* RelayReadingFinishFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55745FC5291B9B9F00414462 /* RelayReadingFinishFooterView.swift */; };
-		55745FE2291CCBDC00414462 /* RelayMainHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55745FDF291CCBDC00414462 /* RelayMainHostingController.swift */; };
+		55745FE2291CCBDC00414462 /* RelayMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55745FDF291CCBDC00414462 /* RelayMainViewController.swift */; };
 		55745FE3291CCBDC00414462 /* PageAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55745FE1291CCBDC00414462 /* PageAnimationView.swift */; };
 		55745FE6291CD93300414462 /* NetworkFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55745FE5291CD93300414462 /* NetworkFiles.swift */; };
 		55867E0C29123C8500C79FFC /* Extension+CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55867E0B29123C8500C79FFC /* Extension+CALayer.swift */; };
@@ -115,7 +115,7 @@
 		55745FC5291B9B9F00414462 /* RelayReadingFinishFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayReadingFinishFooterView.swift; sourceTree = "<group>"; };
 		55745FD7291CCA8600414462 /* RelayMainHostingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelayMainHostingController.swift; sourceTree = "<group>"; };
 		55745FD9291CCA8600414462 /* PageAnimationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageAnimationView.swift; sourceTree = "<group>"; };
-		55745FDF291CCBDC00414462 /* RelayMainHostingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelayMainHostingController.swift; sourceTree = "<group>"; };
+		55745FDF291CCBDC00414462 /* RelayMainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelayMainViewController.swift; sourceTree = "<group>"; };
 		55745FE1291CCBDC00414462 /* PageAnimationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageAnimationView.swift; sourceTree = "<group>"; };
 		55745FE5291CD93300414462 /* NetworkFiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkFiles.swift; sourceTree = "<group>"; };
 		55867E0B29123C8500C79FFC /* Extension+CALayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+CALayer.swift"; sourceTree = "<group>"; };
@@ -390,7 +390,7 @@
 		55745FDE291CCBDC00414462 /* MainView */ = {
 			isa = PBXGroup;
 			children = (
-				55745FDF291CCBDC00414462 /* RelayMainHostingController.swift */,
+				55745FDF291CCBDC00414462 /* RelayMainViewController.swift */,
 				55745FE0291CCBDC00414462 /* Views */,
 			);
 			path = MainView;
@@ -640,7 +640,7 @@
 				B533AB5C291AA5B300B73867 /* RelayDeleteAccountUserActivityView.swift in Sources */,
 				32517E142913B733005E0F69 /* RelayAllReadyViewController.swift in Sources */,
 				55FDCEB5290A711C000AB345 /* RelayProfileUserActivityView.swift in Sources */,
-				55745FE2291CCBDC00414462 /* RelayMainHostingController.swift in Sources */,
+				55745FE2291CCBDC00414462 /* RelayMainViewController.swift in Sources */,
 				55745FC2291A3BF100414462 /* BodyCollectionViewCell.swift in Sources */,
 				32DE2B13291A979D005D1A85 /* DividerView.swift in Sources */,
 				B533AB522919FB8400B73867 /* RelayAboutRelayDescriptionView.swift in Sources */,

--- a/Relay/Relay.xcodeproj/project.pbxproj
+++ b/Relay/Relay.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3201622E2912A7950054803C /* RelayPenNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3201622D2912A7950054803C /* RelayPenNameViewController.swift */; };
+		321F591F291CE77700FEE6DD /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321F591E291CE77700FEE6DD /* CardView.swift */; };
 		32464EB3291B808800BDAB7C /* RelayNoticeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32464EB2291B808800BDAB7C /* RelayNoticeViewController.swift */; };
 		32464EB7291B887D00BDAB7C /* TableCellCustomCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32464EB6291B887D00BDAB7C /* TableCellCustomCell.swift */; };
 		32464EB9291B99E400BDAB7C /* Extension+UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32464EB8291B99E400BDAB7C /* Extension+UIViewController.swift */; };
@@ -77,6 +78,7 @@
 
 /* Begin PBXFileReference section */
 		3201622D2912A7950054803C /* RelayPenNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayPenNameViewController.swift; sourceTree = "<group>"; };
+		321F591E291CE77700FEE6DD /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		32308E43290F983E0012B5A2 /* Relay.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Relay.entitlements; sourceTree = "<group>"; };
 		32464EB2291B808800BDAB7C /* RelayNoticeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayNoticeViewController.swift; sourceTree = "<group>"; };
 		32464EB6291B887D00BDAB7C /* TableCellCustomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableCellCustomCell.swift; sourceTree = "<group>"; };
@@ -400,6 +402,7 @@
 			isa = PBXGroup;
 			children = (
 				55745FE1291CCBDC00414462 /* PageAnimationView.swift */,
+				321F591E291CE77700FEE6DD /* CardView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -636,6 +639,7 @@
 				55FDCEB3290A6440000AB345 /* RelayProfileUserInfoView.swift in Sources */,
 				556F309929103676005D7AF4 /* RelayListHeaderView.swift in Sources */,
 				B5C0B5252914D8BA00077B5F /* RelaySettingViewController.swift in Sources */,
+				321F591F291CE77700FEE6DD /* CardView.swift in Sources */,
 				55867E152912B7DA00C79FFC /* Extension+UIColor.swift in Sources */,
 				B533AB5C291AA5B300B73867 /* RelayDeleteAccountUserActivityView.swift in Sources */,
 				32517E142913B733005E0F69 /* RelayAllReadyViewController.swift in Sources */,

--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -42,7 +42,7 @@ class RelayMainViewController: UIViewController {
     
     private lazy var submitButton: UIButton = {
         let button = UIButton()
-        button.setTitle("확인", for: .normal)
+        button.setTitle("릴레이 시작하기", for: .normal)
         button.setTitleColor(.white, for: .normal)
         button.titleLabel?.font = .boldSystemFont(ofSize: 17)
         

--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import UIKit
 import SnapKit
 
-class RelayMainHostingController: UIViewController {
+class RelayMainViewController: UIViewController {
     
     private let titleLabel: UILabel = {
         let label = UILabel()

--- a/Relay/Relay/Scenes/MainView/Views/CardView.swift
+++ b/Relay/Relay/Scenes/MainView/Views/CardView.swift
@@ -12,6 +12,7 @@ struct CardView: View {
         Rectangle()
             .overlay {
                 ZStack{
+                    // TODO: 이미지는 나중에 이미지만 따로 있을 때 적용 하겠습니다. 지금은 글자와 이미지가 같이 있어서 적용하면 겹쳐보입니다.
 //                    Image("1")
 //                        .resizable()
                     VStack(spacing: 0){

--- a/Relay/Relay/Scenes/MainView/Views/CardView.swift
+++ b/Relay/Relay/Scenes/MainView/Views/CardView.swift
@@ -1,0 +1,90 @@
+//
+//  CardView.swift
+//  Relay
+//
+//  Created by 이창형 on 2022/11/10.
+//
+
+import SwiftUI
+
+struct CardView: View {
+    var body: some View {
+        Rectangle()
+            .overlay {
+                ZStack{
+//                    Image("1")
+//                        .resizable()
+                    VStack(spacing: 0){
+                        HStack(spacing: 0){
+                            
+                            Text("플레이리스트 제목")
+                                .font(.title2)
+                                .bold()
+                                .foregroundColor(.white)
+                                .padding(.top, 25)
+                            
+                            Spacer()
+                            
+                            Button{
+                                
+                            } label: {
+                                Image(systemName: "play.circle")
+                                    .foregroundColor(.white)
+                                    .font(.system(size: 32))
+                            }
+                            .padding(.top, 25)
+                        }
+                        HStack(spacing: 0){
+                            Text("#곡 무드 태그")
+                                .foregroundColor(.white)
+                                .font(.system(size: 13))
+                                .padding(.top, 4)
+                            Spacer()
+                        }
+                        Spacer()
+                        HStack(spacing: 0){
+                            Text("바통을 이어받으세요")
+                                .font(.system(size: 13))
+                                .foregroundColor(.white)
+                            Spacer()
+                        }
+                        .padding(.bottom, 10)
+                        HStack(spacing: 0){
+                            Text("소설 제목입니다")
+                                .font(.system(size: 24))
+                                .bold()
+                                .foregroundColor(.white)
+                            Spacer()
+                        }
+                        .padding(.bottom, 8)
+                        HStack(spacing: 0){
+                            Text("9 / 10")
+                                .font(.system(size: 17))
+                                .bold()
+                                .foregroundColor(.white)
+                            Text(" 터치 ")
+                                .font(.system(size: 17))
+                                .bold()
+                                .foregroundColor(.white)
+                            Image(systemName: "circle.fill")
+                                .foregroundColor(.white)
+                                .font(.system(size: 5))
+                            Text(" SF")
+                                .font(.system(size: 17))
+                                .bold()
+                                .foregroundColor(.white)
+                            Spacer()
+                        }
+                        .padding(.bottom, 25)
+                        
+                    }.padding(.horizontal, 20)
+                }
+            }
+    }
+}
+
+struct CardView_Previews: PreviewProvider {
+    static var previews: some View {
+        CardView()
+    }
+}

--- a/Relay/Relay/Scenes/MainView/Views/PageAnimationView.swift
+++ b/Relay/Relay/Scenes/MainView/Views/PageAnimationView.swift
@@ -15,7 +15,7 @@ struct PageAnimationView: View {
                         .resizable()
                         .scaledToFit()
                     Rectangle()
-                        .frame(width: UIScreen.main.bounds.width, height: 50)
+                        .frame(width: UIScreen.main.bounds.width, height: 70)
                 }
                 GeometryReader { proxy in
                     VStack(spacing: 31) {

--- a/Relay/Relay/Scenes/MainView/Views/PageAnimationView.swift
+++ b/Relay/Relay/Scenes/MainView/Views/PageAnimationView.swift
@@ -49,12 +49,11 @@ struct PageAnimationView: View {
     
     func pageView(_ page: Int) -> some View {
         ZStack {
-            
             if page == 0 {
                 Rectangle()
                     .overlay {
-                        Image("1")
-                            .resizable()
+                        CardView()
+                        
                     }
             }
             

--- a/Relay/Relay/Scenes/TabBarController.swift
+++ b/Relay/Relay/Scenes/TabBarController.swift
@@ -10,7 +10,7 @@ import SnapKit
 
 class TabBarController: UITabBarController {
     private lazy var mainViewController: UIViewController = {
-        let viewController = UINavigationController(rootViewController: RelayMainHostingController())
+        let viewController = UINavigationController(rootViewController: RelayMainViewController())
         let image = UIImage(systemName: "flag")?.resize(newWidth: 19.0)
         let selectedImage = UIImage(systemName: "flag.fill")?.resize(newWidth: 19.0)
         let tabBarItem = UITabBarItem(


### PR DESCRIPTION
## 작업사항
|Xcode|
|:---:|
|![image](https://user-images.githubusercontent.com/71262367/201466406-3265a6e2-3e75-4e4f-9b96-bda778e44f91.png)|

- cardView를 데이터 받을 수 있도록 이미지에서 각각의 객체로 변환
- mainView 이미지 크기 조정
- 확인버튼 -> 릴레이 시작하기 버튼으로 수정

## 이슈번호
- #57 
- #56

close #57 
close #56 
