### PR TITLE
[2022/11/14] feat/relayBrowsingViewControllerConnection >> RelayBrowsingViewController -> RelayReadingViewController, RelayNoticeViewController 연결

### DIFF
--- a/Relay/Relay/SceneDelegate.swift
+++ b/Relay/Relay/SceneDelegate.swift
@@ -24,7 +24,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(frame: UIScreen.main.bounds)
         
         // 위에서 만든 viewController를 첫 화면으로 띄우기
-        window?.rootViewController = UINavigationController(rootViewController: TabBarController())
+        window?.rootViewController = TabBarController()
         
         // 화면에 보이게끔
         window?.makeKeyAndVisible()

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -25,7 +25,7 @@ class RelayBrowsingViewController: UIViewController, UICollectionViewDelegate {
         image: UIImage(systemName: "bell"),
         style: .plain,
         target: self,
-        action: nil
+        action: #selector(touchNoticeButton)
     )
     
     //TODO: develop 브랜치에 merge 후 leftBarItem의 UIImage 크기조절 필요
@@ -247,5 +247,11 @@ extension RelayBrowsingViewController {
         modalViewController.delegate = self
         
         present(modalViewController, animated: true)
+    }
+    
+    @objc private func touchNoticeButton() {
+        let noticeViewController = RelayNoticeViewController()
+        
+        navigationController?.pushViewController(noticeViewController, animated: true)
     }
 }

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-class RelayBrowsingViewController: UIViewController {
+class RelayBrowsingViewController: UIViewController, UICollectionViewDelegate {
     private var selectedCategory: String?
     
     private var currentHighlightedButton: ButtonName? {
@@ -43,6 +43,9 @@ class RelayBrowsingViewController: UIViewController {
         
         currentHighlightedButton = .entire
         
+        relayListView.listCollectionView.delegate = self
+        relayListView.listCollectionView.dataSource = self
+        
         setNavigationBar()
         setupButtonMethod()
         setupLayout()
@@ -65,6 +68,33 @@ extension RelayBrowsingViewController: RelayCategoryDelegate {
             relayListView.listHeaderView?.listFilterButton.setTitle(selectedCategory, for: .normal)
         }
     }
+}
+
+extension RelayBrowsingViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let width = collectionView.frame.width
+        let height = 118.0
+        
+        return CGSize(width: width, height: height)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        0.0
+    }
+}
+
+extension RelayBrowsingViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        4
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RelayListCollectionViewCell.id, for: indexPath) as? RelayListCollectionViewCell else { return UICollectionViewCell() }
+        cell.configure(indexPath.row)
+        
+        return cell
+    }
+
 }
 
 extension RelayBrowsingViewController {

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -84,6 +84,9 @@ extension RelayBrowsingViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         print("tapped \(indexPath.row) cell")
+        let readingViewController = RelayReadingViewController()
+        
+        navigationController?.pushViewController(readingViewController, animated: true)
     }
 }
 

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -81,6 +81,10 @@ extension RelayBrowsingViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         0.0
     }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        print("tapped \(indexPath.row) cell")
+    }
 }
 
 extension RelayBrowsingViewController: UICollectionViewDataSource {

--- a/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
+++ b/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
@@ -254,6 +254,7 @@ extension RelayReadingViewController {
     }
     
     @objc func popViewController() {
+        navigationController?.navigationBar.isHidden = false
         navigationController?.popViewController(animated: true)
     }
     

--- a/Relay/Relay/Scenes/Reusable/RelayListView/RelayListView.swift
+++ b/Relay/Relay/Scenes/Reusable/RelayListView/RelayListView.swift
@@ -10,12 +10,10 @@ import SnapKit
 
 class RelayListView: UIView {
     var listHeaderView: RelayListHeaderView?
-    private lazy var listCollectionView: UICollectionView = {
+    lazy var listCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         
-        collectionView.delegate = self
-        collectionView.dataSource = self
         collectionView.register(RelayListCollectionViewCell.self, forCellWithReuseIdentifier: RelayListCollectionViewCell.id)
         
         return collectionView
@@ -31,33 +29,6 @@ class RelayListView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-}
-
-extension RelayListView: UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = collectionView.frame.width
-        let height = 118.0
-        
-        return CGSize(width: width, height: height)
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        0.0
-    }
-}
-
-extension RelayListView: UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        4
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RelayListCollectionViewCell.id, for: indexPath) as? RelayListCollectionViewCell else { return UICollectionViewCell() }
-        cell.configure(indexPath.row)
-        
-        return cell
-    }
-
 }
 
 extension RelayListView {


### PR DESCRIPTION
## 작업사항
1. RelayListView에 데이터전달 및 동작을 View가 아닌 ViewController에서 관리하기 위해 RelayListView의 UICollectionViewDelegateFlowLayout, UICollectionViewDataSourece를 RelayBrowsingViewController가 상속하도록 수정하였습니다. 

2. RelayBrowsingViewController -> RelayReadingViewController 연결

3. RelayNoticeViewController -> RelayNoticeViewController 연결

|구현영상|
|:---:|
|<img width="300" alt="둘러보기 - Figma" src="https://user-images.githubusercontent.com/83946704/201660267-553c36d6-085b-42f7-9608-83850555c0f3.gif">|

## 이슈번호
- #60 

## 특이사항(Optional)
1. RelayReadingViewController에서 RelayBrowsingViewController로 돌아나오는 순간에  NavigationBar Back Button이 흐릿하게 나타났다가 사라지는 현상이 있습니다. RelayReadingViewController의 네비게이션바를 커스텀했기 때문에 발생하는 오류라고 예상되고 디자인적인 통일을 위해 RelayReadingViewController의 네비게이션 바를 기존 네비게이션바의 설정을 통해 구현하는 방식으로 변경이 필요합니다.
2. RelayNoticeViewController의 네비게이션 바도 커스텀으로 구현되었기 때문에 1번과 동일한 이유로 수정이 필요합니다.

close #60 