### PR TITLE
[2022/11/16] refactor/relayCategoryViewController >> RelayCategoryViewController에 원하는 카테고리를 넣어 사용할 수 있도록 리팩토링, RelayWritingViewController와 연결

### DIFF
--- a/Relay/Pods/Pods.xcodeproj/xcshareddata/xcschemes/RxCocoa.xcscheme
+++ b/Relay/Pods/Pods.xcodeproj/xcshareddata/xcschemes/RxCocoa.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7AD0C6DCDC9CEC8A3C7C10C7FEE07BE6"
+               BuildableName = "RxCocoa.framework"
+               BlueprintName = "RxCocoa"
+               ReferencedContainer = "container:Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3265BA25290925DD00532CA4"
+            BuildableName = "Relay.app"
+            BlueprintName = "Relay"
+            ReferencedContainer = "container:../Relay.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7AD0C6DCDC9CEC8A3C7C10C7FEE07BE6"
+            BuildableName = "RxCocoa.framework"
+            BlueprintName = "RxCocoa"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Relay/Relay.xcodeproj/xcshareddata/xcschemes/Relay.xcscheme
+++ b/Relay/Relay.xcodeproj/xcshareddata/xcschemes/Relay.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3265BA25290925DD00532CA4"
+               BuildableName = "Relay.app"
+               BlueprintName = "Relay"
+               ReferencedContainer = "container:Relay.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3265BA25290925DD00532CA4"
+            BuildableName = "Relay.app"
+            BlueprintName = "Relay"
+            ReferencedContainer = "container:Relay.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3265BA25290925DD00532CA4"
+            BuildableName = "Relay.app"
+            BlueprintName = "Relay"
+            ReferencedContainer = "container:Relay.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Relay/Relay/Relay.entitlements
+++ b/Relay/Relay/Relay.entitlements
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
 </plist>

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -239,7 +239,8 @@ extension RelayBrowsingViewController {
     }
     
     @objc private func touchListFilterButton() {
-        let modalViewController = RelayCategoryViewController()
+        let list = ["전체", "로맨스", "스릴러/공포", "판타지", "SF", "추리", "무협", "시대극", "일반", "기타"]
+        let modalViewController = RelayCategoryViewController(list: list)
         
         modalViewController.fetchSelectedCateogry(selectedCategory)
         modalViewController.modalPresentationStyle = .custom

--- a/Relay/Relay/Scenes/Reusable/CategoryView/RelayCategoryViewController.swift
+++ b/Relay/Relay/Scenes/Reusable/CategoryView/RelayCategoryViewController.swift
@@ -138,7 +138,12 @@ extension RelayCategoryViewController {
     }
     
     @objc private func dismissViewController() {
-        delegate?.didApplyCategory(selectedCategory: selectedCategory ?? "전체")
+        if let selectedCategory = self.selectedCategory {
+            delegate?.didApplyCategory(selectedCategory: selectedCategory)
+        } else {
+            delegate?.didApplyCategory(selectedCategory: categoryList.first ?? "")
+        }
+        
         dismiss(animated: true)
     }
 }

--- a/Relay/Relay/Scenes/Reusable/CategoryView/RelayCategoryViewController.swift
+++ b/Relay/Relay/Scenes/Reusable/CategoryView/RelayCategoryViewController.swift
@@ -10,7 +10,7 @@ import SnapKit
 
 // TODO: 플레이리스트 모달로도 재사용 가능하도록 리팩토링 필요
 class RelayCategoryViewController: UIViewController {
-    private let categoryList = ["전체", "로맨스", "스릴러/공포", "판타지", "SF", "추리", "무협", "시대극", "일반", "기타"]
+    var categoryList: [String]
     private var selectedCategory: String?
     
     weak var delegate: RelayCategoryDelegate?
@@ -31,7 +31,7 @@ class RelayCategoryViewController: UIViewController {
         
         var titleAttribute = AttributedString("적용하기")
         titleAttribute.font = .systemFont(ofSize: 16.0, weight: .bold)
-        titleAttribute.foregroundColor = .white
+        titleAttribute.foregroundColor = UIColor.white
         
         button.setAttributedTitle(NSAttributedString(titleAttribute), for: .normal)
         button.titleEdgeInsets = UIEdgeInsets(top: -11.0, left: 0.0, bottom: 11.0, right: 0.0)
@@ -41,6 +41,16 @@ class RelayCategoryViewController: UIViewController {
         
         return button
     }()
+    
+    init(list: [String]) {
+        categoryList = list
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -69,7 +79,7 @@ extension RelayCategoryViewController: UICollectionViewDelegateFlowLayout {
 
 extension RelayCategoryViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        10
+        categoryList.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
+++ b/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 
 class RelayWritingViewController: UIViewController, UICollectionViewDelegate {
+    private var selectedCategory: String?
     
     private let closeButton: UIButton = {
         let button = UIButton(type: .custom)
@@ -51,6 +52,8 @@ class RelayWritingViewController: UIViewController, UICollectionViewDelegate {
         button.semanticContentAttribute = .forceLeftToRight
         button.imageEdgeInsets = .init(top: 0, left: 20, bottom: 0, right: 0)
         button.titleEdgeInsets = .init(top: 0, left: 28, bottom: 0, right: 0)
+        
+        button.addTarget(self, action: #selector(touchMusicListButton), for: .touchUpInside)
         
         return button
     }()
@@ -238,6 +241,22 @@ class RelayWritingViewController: UIViewController, UICollectionViewDelegate {
     }
 }
 
+extension RelayWritingViewController: UIViewControllerTransitioningDelegate {
+    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        CategoryModalPresentationController(presentedViewController: presented, presenting: presenting)
+        }
+}
+
+extension RelayWritingViewController: RelayCategoryDelegate {
+    func didApplyCategory(selectedCategory: String) {
+        self.selectedCategory = selectedCategory
+        
+        if let selectedPlaylist = self.selectedCategory {
+            musicListButton.setTitle(selectedPlaylist, for: .normal)
+        }
+    }
+}
+
 extension RelayWritingViewController {
     
     @objc
@@ -332,6 +351,19 @@ extension RelayWritingViewController {
                 }
             }
         }
+    }
+    
+    @objc func touchMusicListButton() {
+        let list = ["플레이리스트1", "플레이리스트2", "플레이리스트3", "플레이리스트4", "플레이리스트5", "플레이리스트6", "플레이리스트7", "플레이리스트8", "플레이리스트9", "플레이리스트10"]
+        
+        let modalViewController = RelayCategoryViewController(list: list)
+        
+        modalViewController.fetchSelectedCateogry(selectedCategory)
+        modalViewController.modalPresentationStyle = .custom
+        modalViewController.transitioningDelegate = self
+        modalViewController.delegate = self
+        
+        present(modalViewController, animated: true)
     }
     
     private func updateCountLabel(characterCount: Int) {


### PR DESCRIPTION
## 작업사항
1. RelayCategoryViewController를 모달로 나타낼때 내부에 존재하는 리스트를 모달을 띄우는 해당 ViewController에서 리스트 데이터를 전달해 사용할 수 있도록 리팩토링하였습니다.
2. RelayWritingViewController에서 '플레이리스트 선택'버튼을 누르면 플레이리스트 1~10이 나타나고 선택 후 '적용하기' 버튼을 누를 시 해당 플레이리스트가 버튼 텍스트로 나타나도록 구현하였습니다.

|구현영상|
|:---:|
|<img width="300" alt="둘러보기(모달) - Figma" src="https://user-images.githubusercontent.com/83946704/202099155-84b90fa5-78e5-4de9-beed-c01e41caa78d.gif">|

## 이슈번호
- #42 

## 특이사항(Optional)
데이터구조 확인 후 플레이리스트 또는 장르선택 후 데이터전달 방식을 새롭게 적용시켜 구현해야합니다.

close #42 