### PR TITLE
[2022/11/16] feat/realyNoticeViewNavigationBar >> 메인뷰 노티뷰 연결, 메인뷰 노티뷰 네비게이션 커스텀

### DIFF
--- a/Relay/Relay/Info.plist
+++ b/Relay/Relay/Info.plist
@@ -23,5 +23,10 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>

--- a/Relay/Relay/Relay.entitlements
+++ b/Relay/Relay/Relay.entitlements
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
 </plist>

--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -11,13 +11,15 @@ import SnapKit
 
 class RelayMainViewController: UIViewController {
     
+    //TODO: 알람이 있을때 이미지 변경 필요
     private lazy var noticeButton = UIBarButtonItem(
         image: UIImage(systemName: "bell"),
         style: .plain,
         target: self,
-        action: #selector(goToWritingView)
+        action: #selector(goToNoticeView)
     )
     
+    //TODO: 이미지 크기 변경 필요
     private lazy var logoButton = UIBarButtonItem(
         image: UIImage(named: "RelayLogo"),
         style: .plain,
@@ -66,6 +68,13 @@ extension RelayMainViewController {
         
         navigationItem.leftBarButtonItem = logoButton
         navigationItem.rightBarButtonItem = noticeButton
+    }
+    
+    @objc
+    private func goToNoticeView() {
+        let noticeViewController = RelayNoticeViewController()
+        
+        navigationController?.pushViewController(noticeViewController, animated: true)
     }
     
     @objc

--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -21,15 +21,15 @@ class RelayMainViewController: UIViewController {
         return label
     }()
     
-    private let bellImageView: UIImageView = {
-        let imageView = UIImageView()
+    private let bellButton: UIButton = {
+        let button = UIButton()
         let config = UIImage.SymbolConfiguration(pointSize: 22)
         let image = UIImage(systemName: "bell", withConfiguration: config)
         
-        imageView.image = image
-        imageView.tintColor = UIColor.relayBlack
+        button.setImage(image, for: .normal)
+        button.tintColor = .relayBlack
         
-        return imageView
+        return button
     }()
     
     private let animationView: UIView = {
@@ -76,7 +76,7 @@ class RelayMainViewController: UIViewController {
     private func setupLayout() {
         [
             titleLabel,
-            bellImageView,
+            bellButton,
             animationView
             
         ].forEach { view.addSubview($0) }
@@ -87,7 +87,7 @@ class RelayMainViewController: UIViewController {
             $0.top.equalToSuperview().inset(65.0)
             $0.leading.equalToSuperview().inset(20.0)
         }
-        bellImageView.snp.makeConstraints {
+        bellButton.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.top)
             $0.trailing.equalToSuperview().inset(20.0)
         }

--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -11,26 +11,19 @@ import SnapKit
 
 class RelayMainViewController: UIViewController {
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        
-        label.text = "릴레이"
-        label.textColor = UIColor.relayPink1
-        label.font = UIFont(name: "CWDangamAsac-Bold", size: 20.0)
-        
-        return label
-    }()
+    private lazy var noticeButton = UIBarButtonItem(
+        image: UIImage(systemName: "bell"),
+        style: .plain,
+        target: self,
+        action: #selector(goToWritingView)
+    )
     
-    private let bellButton: UIButton = {
-        let button = UIButton()
-        let config = UIImage.SymbolConfiguration(pointSize: 22)
-        let image = UIImage(systemName: "bell", withConfiguration: config)
-        
-        button.setImage(image, for: .normal)
-        button.tintColor = .relayBlack
-        
-        return button
-    }()
+    private lazy var logoButton = UIBarButtonItem(
+        image: UIImage(named: "RelayLogo"),
+        style: .plain,
+        target: self,
+        action: nil
+    )
     
     private let animationView: UIView = {
         let view = UIView()
@@ -61,12 +54,19 @@ class RelayMainViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .white
         self.addAnimationView()
-        
+        setNavigationBar()
         setupLayout()
     }
 }
 
 extension RelayMainViewController {
+    private func setNavigationBar() {
+        noticeButton.tintColor = .relayBlack
+        logoButton.tintColor = .relayPink1
+        
+        navigationItem.leftBarButtonItem = logoButton
+        navigationItem.rightBarButtonItem = noticeButton
+    }
     
     @objc
     func goToWritingView(_ sender: UIButton!) {
@@ -78,24 +78,13 @@ extension RelayMainViewController {
     
     private func setupLayout() {
         [
-            titleLabel,
-            bellButton,
             animationView
             
         ].forEach { view.addSubview($0) }
-        
         animationView.addSubview(submitButton)
         
-        titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(65.0)
-            $0.leading.equalToSuperview().inset(20.0)
-        }
-        bellButton.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.top)
-            $0.trailing.equalToSuperview().inset(20.0)
-        }
         animationView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(30.0)
+            $0.top.equalToSuperview().inset(120.0)
             $0.leading.equalToSuperview()
             $0.bottom.equalToSuperview()
             $0.trailing.equalToSuperview()

--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -64,6 +64,9 @@ class RelayMainViewController: UIViewController {
         
         setupLayout()
     }
+}
+
+extension RelayMainViewController {
     
     @objc
     func goToWritingView(_ sender: UIButton!) {
@@ -114,4 +117,5 @@ class RelayMainViewController: UIViewController {
         addChild(hostingController)
         animationView.addSubview(hostingController.view)
     }
+    
 }

--- a/Relay/Relay/Scenes/NoticeView/RelayNoticeViewController.swift
+++ b/Relay/Relay/Scenes/NoticeView/RelayNoticeViewController.swift
@@ -10,20 +10,13 @@ import SnapKit
 
 class RelayNoticeViewController: UIViewController {
     
-    //    private lazy var noticeButton = UIBarButtonItem(
-    //        image: UIImage(systemName: "bell"),
-    //        style: .plain,
-    //        target: self,
-    //        action: #selector(goToNoticeView)
-    //    )
-    //
-    //    //TODO: 이미지 크기 변경 필요
-    //    private lazy var logoButton = UIBarButtonItem(
-    //        image: UIImage(named: "RelayLogo"),
-    //        style: .plain,
-    //        target: self,
-    //        action: nil
-    //    )
+    //TODO: 삭제 기능 구현
+    private lazy var trashBarButtonItem = UIBarButtonItem(
+        image: UIImage(systemName: "trash"),
+        style: .plain,
+        target: self,
+        action: nil
+    )
     
     private lazy var backBarButtonItem = UIBarButtonItem(
         title: "",
@@ -64,6 +57,9 @@ extension RelayNoticeViewController {
         navigationController?.navigationBar.backIndicatorTransitionMaskImage = UIImage(systemName: "arrow.left")
         navigationController?.navigationBar.tintColor = .relayBlack
         navigationController?.navigationBar.topItem?.title = ""
+        
+        navigationItem.title = "알림"
+        navigationItem.rightBarButtonItem = trashBarButtonItem
     }
     
     private func setupTableView() {
@@ -79,7 +75,7 @@ extension RelayNoticeViewController {
         ].forEach { view.addSubview($0) }
         
         tableView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(28.0)
+            $0.top.equalToSuperview().inset(110.0)
             $0.leading.equalToSuperview()
             $0.trailing.equalToSuperview()
             $0.bottom.equalToSuperview()

--- a/Relay/Relay/Scenes/NoticeView/RelayNoticeViewController.swift
+++ b/Relay/Relay/Scenes/NoticeView/RelayNoticeViewController.swift
@@ -10,35 +10,27 @@ import SnapKit
 
 class RelayNoticeViewController: UIViewController {
     
-    private let backButton: UIButton = {
-        let button = UIButton(type: .custom)
-        let config = UIImage.SymbolConfiguration(pointSize: 22)
-        let image = UIImage(systemName: "arrow.left", withConfiguration: config)
-        
-        button.setImage(image: image!)
-        button.tintColor = .relayBlack
-        
-        return button
-    }()
+    //    private lazy var noticeButton = UIBarButtonItem(
+    //        image: UIImage(systemName: "bell"),
+    //        style: .plain,
+    //        target: self,
+    //        action: #selector(goToNoticeView)
+    //    )
+    //
+    //    //TODO: 이미지 크기 변경 필요
+    //    private lazy var logoButton = UIBarButtonItem(
+    //        image: UIImage(named: "RelayLogo"),
+    //        style: .plain,
+    //        target: self,
+    //        action: nil
+    //    )
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        
-        label.text = "알림"
-        label.setFont(.caption1)
-        
-        return label
-    }()
-    
-    private let trashButton: UIButton = {
-        let button = UIButton()
-        let config = UIImage.SymbolConfiguration(pointSize: 22)
-        let image = UIImage(systemName: "trash", withConfiguration: config)
-        
-        button.setImage(image, for: .normal)
-        
-        return button
-    }()
+    private lazy var backBarButtonItem = UIBarButtonItem(
+        title: "",
+        style: .plain,
+        target: self,
+        action: nil
+    )
     
     private let dividerTop: UIView = {
         let view = UIView()
@@ -61,11 +53,19 @@ class RelayNoticeViewController: UIViewController {
         view.backgroundColor = .white
         setupTableView()
         setupLayout()
-        
+        setNavigationBar()
     }
 }
 
 extension RelayNoticeViewController {
+    
+    private func setNavigationBar() {
+        navigationController?.navigationBar.backIndicatorImage = UIImage(systemName: "arrow.left")
+        navigationController?.navigationBar.backIndicatorTransitionMaskImage = UIImage(systemName: "arrow.left")
+        navigationController?.navigationBar.tintColor = .relayBlack
+        navigationController?.navigationBar.topItem?.title = ""
+    }
+    
     private func setupTableView() {
         tableView.register(TableCellCustomCell.self, forCellReuseIdentifier: TableCellCustomCell.reuseIdentifier)
         tableView.dataSource = self
@@ -74,26 +74,10 @@ extension RelayNoticeViewController {
     
     private func setupLayout() {
         [
-            backButton,
-            titleLabel,
-            trashButton,
             tableView,
             dividerTop
         ].forEach { view.addSubview($0) }
         
-        backButton.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(60.0)
-            $0.leading.equalToSuperview().inset(18.0)
-            $0.width.height.equalTo(26.0)
-        }
-        titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(64.0)
-            $0.centerX.equalTo(view.snp.centerX)
-        }
-        trashButton.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(60.0)
-            $0.trailing.equalToSuperview().inset(20.0)
-        }
         tableView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(28.0)
             $0.leading.equalToSuperview()
@@ -112,11 +96,11 @@ extension RelayNoticeViewController {
 extension RelayNoticeViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-            return 20
+        return 20
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {
-            return 1
+        return 1
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
## 작업사항

|<img width="300" alt="Xcode" src="https://user-images.githubusercontent.com/71262367/202105716-5dc45f4f-1a5a-4b75-abc1-668736279f51.mp4">|

- mainView와 notice뷰를 네비게이션으로 연결했습니다
- mainView 상단 바를 기본 네비게이션 바를 커스텀하여 구현했습니다
- notice뷰 상단 바를 기본 네비게이션 바를 커스텀하여 구현했습니다

## 이슈번호
- #67 

## 특이사항(Optional)
- 릴레이 이미지 조정이 필요합니다
- 데이터를 받고 삭제 기능 구현이 필요합니다
- TODO로 주석처리 해놨습니다

close #67 