### PR TITLE
[2022/11/22] Feat/navigationLogoButtonDetail >> 네비게이션 로고버튼 비활성화 및 색 변경 방지

### DIFF
--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -30,7 +30,7 @@ class RelayBrowsingViewController: UIViewController, UICollectionViewDelegate {
     
     //TODO: develop 브랜치에 merge 후 leftBarItem의 UIImage 크기조절 필요
     private lazy var logoButton = UIBarButtonItem(
-        image: UIImage(named: "RelayLogo")?.resize(newWidth: 56),
+        image: UIImage(named: "RelayLogo")?.resize(newWidth: 56).withRenderingMode(.alwaysOriginal),
         style: .plain,
         target: self,
         action: nil
@@ -134,7 +134,7 @@ extension RelayBrowsingViewController {
     
     private func setNavigationBar() {
         noticeButton.tintColor = .relayBlack
-        logoButton.tintColor = .relayPink1
+        logoButton.isEnabled = false
         
         navigationItem.leftBarButtonItem = logoButton
         navigationItem.rightBarButtonItem = noticeButton

--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -21,7 +21,7 @@ class RelayMainViewController: UIViewController {
     
     //TODO: 이미지 크기 변경 필요
     private lazy var logoButton = UIBarButtonItem(
-        image: UIImage(named: "RelayLogo")?.resize(newWidth: 56),
+        image: UIImage(named: "RelayLogo")?.resize(newWidth: 56).withRenderingMode(.alwaysOriginal),
         style: .plain,
         target: self,
         action: nil
@@ -65,7 +65,7 @@ class RelayMainViewController: UIViewController {
 extension RelayMainViewController {
     private func setNavigationBar() {
         noticeButton.tintColor = .relayBlack
-        logoButton.tintColor = .relayPink1
+        logoButton.isEnabled = false
         
         navigationItem.leftBarButtonItem = logoButton
         navigationItem.rightBarButtonItem = noticeButton


### PR DESCRIPTION
## 작업사항
- 메인뷰, 둘러보기뷰, 네비게이션 로고버튼 비활성화 및 색 변경 방지
- image에 renderingmode를 걸어 색 변경 방지했습니다

## 이슈번호
- #82 

close #82 
