### PR TITLE
[2022/11/23] feat/onboarding logic >> 온보딩 최초 실행 및 로그인 여부 확인 로직 구현

### DIFF
--- a/Relay/Relay/Scenes/TabBarController.swift
+++ b/Relay/Relay/Scenes/TabBarController.swift
@@ -38,7 +38,7 @@ class TabBarController: UITabBarController {
         )
         
         tabBarItem.selectedImage = selectedImage
-
+        
         viewController.view.backgroundColor = .systemBackground
         viewController.tabBarItem = tabBarItem
         
@@ -62,15 +62,13 @@ class TabBarController: UITabBarController {
         return viewController
     }()
     
-    
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         tabBar.backgroundColor = .systemBackground
         setupTabBar()
     }
-    
+    }
 }
 
 extension TabBarController {
@@ -88,5 +86,18 @@ extension TabBarController {
         tabBar.tintColor = .systemPink
         tabBar.layer.borderWidth = 1.0
         tabBar.layer.borderColor = UIColor.systemGray6.cgColor
+    }
+}
+
+extension TabBarController {
+    
+    func checkIsFirst() -> Bool {
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: "isFirstTime") == nil {
+            defaults.set("No", forKey:"isFirstTime")
+            return true
+        } else {
+            return false
+        }
     }
 }

--- a/Relay/Relay/Scenes/TabBarController.swift
+++ b/Relay/Relay/Scenes/TabBarController.swift
@@ -90,6 +90,23 @@ extension TabBarController {
 }
 
 extension TabBarController {
+    func changeView(isFirst: Bool) {
+        if isFirst {
+            print("first")
+            let layout = UICollectionViewFlowLayout()
+            layout.scrollDirection = .horizontal
+            let toRelayOnboardingView = RelayOnboardingViewController(collectionViewLayout: layout)
+            toRelayOnboardingView.modalPresentationStyle = .fullScreen
+            present(toRelayOnboardingView, animated: false, completion: nil)
+        }
+        
+        else {
+            print("else")
+            let toRelayLoginView = RelayLoginViewController()
+            toRelayLoginView.modalPresentationStyle = .fullScreen
+            present(toRelayLoginView, animated: false, completion: nil)
+        }
+    }
     
     func checkIsFirst() -> Bool {
         let defaults = UserDefaults.standard

--- a/Relay/Relay/Scenes/TabBarController.swift
+++ b/Relay/Relay/Scenes/TabBarController.swift
@@ -68,6 +68,12 @@ class TabBarController: UITabBarController {
         tabBar.backgroundColor = .systemBackground
         setupTabBar()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        let isFirst = checkIsFirst()
+        DispatchQueue.main.asyncAfter(deadline: .now().advanced(by: .seconds(0))) { [weak self] in
+            self?.changeView(isFirst: isFirst)
+        }
     }
 }
 

--- a/Relay/Relay/Scenes/TabBarController.swift
+++ b/Relay/Relay/Scenes/TabBarController.swift
@@ -71,8 +71,9 @@ class TabBarController: UITabBarController {
     
     override func viewDidAppear(_ animated: Bool) {
         let isFirst = checkIsFirst()
+        let isLogin = checkIsLoggedIn()
         DispatchQueue.main.asyncAfter(deadline: .now().advanced(by: .seconds(0))) { [weak self] in
-            self?.changeView(isFirst: isFirst)
+            self?.changeView(isFirst: isFirst, isLogin: isLogin)
         }
     }
 }
@@ -96,18 +97,20 @@ extension TabBarController {
 }
 
 extension TabBarController {
-    func changeView(isFirst: Bool) {
+    func changeView(isFirst: Bool, isLogin: Bool) {
         if isFirst {
-            print("first")
+            print("isfirst")
             let layout = UICollectionViewFlowLayout()
             layout.scrollDirection = .horizontal
             let toRelayOnboardingView = RelayOnboardingViewController(collectionViewLayout: layout)
             toRelayOnboardingView.modalPresentationStyle = .fullScreen
             present(toRelayOnboardingView, animated: false, completion: nil)
         }
-        
+        else if isLogin {
+            print("notfirst && isLogin")
+        }
         else {
-            print("else")
+            print("notfirst && notLogin")
             let toRelayLoginView = RelayLoginViewController()
             toRelayLoginView.modalPresentationStyle = .fullScreen
             present(toRelayLoginView, animated: false, completion: nil)
@@ -118,6 +121,16 @@ extension TabBarController {
         let defaults = UserDefaults.standard
         if defaults.object(forKey: "isFirstTime") == nil {
             defaults.set("No", forKey:"isFirstTime")
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    func checkIsLoggedIn() -> Bool {
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: "isAutoLogin") == nil {
+            defaults.set("No", forKey:"isAutoLogin")
             return true
         } else {
             return false


### PR DESCRIPTION
## 작업사항
최초실행 여부 및 로그인 여부에 따른 뷰 연결로직 구현했습니다. 

 - 최초 실행 O 
![온보딩](https://user-images.githubusercontent.com/70955060/203541887-03c045ae-9ccd-42ea-86f3-5e7fa96bbc6d.gif)

 - 최초 실행 X 로그인 O 
![탭바](https://user-images.githubusercontent.com/70955060/203541919-4134241f-d23f-4b96-a9df-e439dc24bd99.gif)

- 최초 실행 X 로그인 X 
![로그인](https://user-images.githubusercontent.com/70955060/203541870-57a11d11-0d17-4c01-ba8d-00aa9f256a1c.gif)

## 이슈번호
- #87 

## 특이사항(Optional)
특이사항이 있을 경우 작성해주세요.

close #87 