### PR TITLE
[2022/11/23] design/settingNavigationBarCustom >> 세팅뷰 및 하위 뷰들의 네비게이션바 커스텀

### DIFF
--- a/Relay/Relay/Scenes/DeleteAccountView/RelayDeleteAccountViewController.swift
+++ b/Relay/Relay/Scenes/DeleteAccountView/RelayDeleteAccountViewController.swift
@@ -25,6 +25,7 @@ class RelayDeleteAccountViewController: UIViewController {
         
         view.backgroundColor = .white
         setupLayout()
+        navigationBarCustom()
     }
 }
 
@@ -47,5 +48,12 @@ extension RelayDeleteAccountViewController {
             $0.trailing.equalToSuperview()
             $0.bottom.equalToSuperview()
         }
+    }
+    
+    private func navigationBarCustom() {
+        navigationController?.navigationBar.backIndicatorImage = UIImage(systemName: "arrow.left")
+        navigationController?.navigationBar.backIndicatorTransitionMaskImage = UIImage(systemName: "arrow.left")
+        navigationController?.navigationBar.tintColor = .relayBlack
+        navigationController?.navigationBar.topItem?.title = ""
     }
 }

--- a/Relay/Relay/Scenes/SettingView/RelayAboutRelayViewController.swift
+++ b/Relay/Relay/Scenes/SettingView/RelayAboutRelayViewController.swift
@@ -37,6 +37,7 @@ class RelayAboutRelayViewController: UIViewController, UITableViewDelegate, UITa
         relaySettingViewConfigure()
         setupLayout()
         tableViewSetupLayout()
+        navigationBarCustom()
     }
     
     func relaySettingViewConfigure() {
@@ -113,5 +114,12 @@ extension RelayAboutRelayViewController {
         tableView.backgroundColor = .relayGray2
         tableView.tableFooterView = UIView(frame: CGRect.zero)
         tableView.separatorColor = self.tableView.backgroundColor
+    }
+    
+    private func navigationBarCustom() {
+        navigationController?.navigationBar.backIndicatorImage = UIImage(systemName: "arrow.left")
+        navigationController?.navigationBar.backIndicatorTransitionMaskImage = UIImage(systemName: "arrow.left")
+        navigationController?.navigationBar.tintColor = .relayBlack
+        navigationController?.navigationBar.topItem?.title = ""
     }
 }

--- a/Relay/Relay/Scenes/SettingView/RelayMyInfoViewController.swift
+++ b/Relay/Relay/Scenes/SettingView/RelayMyInfoViewController.swift
@@ -35,6 +35,7 @@ class RelayMyInfoViewController: UIViewController, UITableViewDelegate, UITableV
         
         relaySettingViewConfigure()
         tableViewSetupLayout()
+        navigationBarCustom()
         
     }
     
@@ -109,6 +110,12 @@ extension RelayMyInfoViewController {
         tableView.tableFooterView = UIView(frame: CGRect.zero)
         tableView.separatorColor = .relayGray2
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+    }
+    private func navigationBarCustom() {
+        navigationController?.navigationBar.backIndicatorImage = UIImage(systemName: "arrow.left")
+        navigationController?.navigationBar.backIndicatorTransitionMaskImage = UIImage(systemName: "arrow.left")
+        navigationController?.navigationBar.tintColor = .relayBlack
+        navigationController?.navigationBar.topItem?.title = ""
     }
 }
 

--- a/Relay/Relay/Scenes/SettingView/RelaySettingViewController.swift
+++ b/Relay/Relay/Scenes/SettingView/RelaySettingViewController.swift
@@ -38,6 +38,7 @@ class RelaySettingViewController: UIViewController, UITableViewDelegate, UITable
         
         relaySettingViewConfigure()
         tableViewSetupLayout()
+        navigationBarCustom()
     }
     
     func relaySettingViewConfigure() {
@@ -145,6 +146,12 @@ extension RelaySettingViewController {
         tableView.tableFooterView = UIView(frame: CGRect.zero)
         tableView.separatorColor = .relayGray2
         tableView.register(UITableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: "customHeader")
+    }
+    private func navigationBarCustom() {
+        navigationController?.navigationBar.backIndicatorImage = UIImage(systemName: "arrow.left")
+        navigationController?.navigationBar.backIndicatorTransitionMaskImage = UIImage(systemName: "arrow.left")
+        navigationController?.navigationBar.tintColor = .relayBlack
+        navigationController?.navigationBar.topItem?.title = ""
     }
 }
 


### PR DESCRIPTION
## 작업사항
설정뷰 및 하위뷰(내정보뷰, 릴레이에대해서뷰, 회원탈퇴뷰)들의 뒤로가기 네비게이션바 커스텀 완료했습니다.

## 이슈번호
- #68 

## 특이사항(Optional)
특이사항이 있을 경우 작성해주세요.

close #68 