### PR TITLE
[2022/11/24] design/relayWritingViewControllerButtons >> 완주버튼, 좋아요버튼 디자인 수정

### DIFF
--- a/Relay/Relay/Scenes/ReadingView/Views/RelayReadingCoverView.swift
+++ b/Relay/Relay/Scenes/ReadingView/Views/RelayReadingCoverView.swift
@@ -32,7 +32,7 @@ class RelayReadingCoverView: UIView {
         
         label.clipsToBounds = true
         label.backgroundColor = .relayPink1
-        label.layer.cornerRadius = 12.0
+        label.layer.cornerRadius = 11.0
         
         return label
     }()
@@ -69,7 +69,7 @@ extension RelayReadingCoverView {
             statusLabel.textColor = .relayPink1
             statusLabel.layer.borderColor = UIColor.relayPink1.cgColor
             statusLabel.layer.borderWidth = 1.0
-            statusLabel.backgroundColor = .systemBackground
+            statusLabel.backgroundColor = .none
         } else {
             statusLabel.text = "달리는중"
         }

--- a/Relay/Relay/Scenes/ReadingView/Views/RelayReadingFinishFooterView.swift
+++ b/Relay/Relay/Scenes/ReadingView/Views/RelayReadingFinishFooterView.swift
@@ -69,7 +69,8 @@ extension RelayReadingFinishFooterView {
         if isLikedUser {
             likeButton.tintColor = .relayPink1
         } else {
-            likeButton.tintColor = .relayGray
+            let image = UIImage(systemName: "heart")
+            likeButton.setImage(image, for: .normal)
         }
         
         likeButton.setTitle("\(likeCount)", for: .normal)

--- a/Relay/Relay/Scenes/ReadingView/Views/RelayReadingFooterView.swift
+++ b/Relay/Relay/Scenes/ReadingView/Views/RelayReadingFooterView.swift
@@ -56,7 +56,8 @@ extension RelayReadingFooterView {
         if isLikedUser {
             likeButton.tintColor = .relayPink1
         } else {
-            likeButton.tintColor = .relayGray
+            let image = UIImage(systemName: "heart")
+            likeButton.setImage(image, for: .normal)
         }
         
         likeButton.setTitle("\(likeCount)", for: .normal)


### PR DESCRIPTION
## 작업사항
1. 완주상태일때 완주버튼의 배경색이 투명하도록 수정하였습니다.
2. 좋아요버튼이 좋아요하지 않은 상태일 때 테두리만 색이 있는 하트이미지가 되도록 수정하였습니다.3. 

|구현이미지 - 완주버튼|구현이미지 - 좋아요버튼|Figma|
|:---:|:---:|:---:|
|<img width="300" alt="읽기 - 감상모드" src="https://user-images.githubusercontent.com/83946704/203716937-9e73719d-893b-411d-a194-5b74171d4b51.png">|<img width="300" alt="읽기 - 감상모드" src="https://user-images.githubusercontent.com/83946704/203716903-c8f60d47-a3c6-4eca-bfdd-907c53a9afeb.png">|<img width="300" alt="읽기 - 감상모드" src="https://user-images.githubusercontent.com/83946704/203716986-c6979a4e-a5d9-4e23-a99e-087975dc27ae.png">|

## 이슈번호
- #92 
