### PR TITLE
[2022/11/26] feat/relayWritingViewControllerPushStyle >> RelayReadingViewController가 나타날 때 탭바가 안보이도록 구현

### DIFF
--- a/Relay/Relay/Scenes/ActivityView/RelayActivityViewController.swift
+++ b/Relay/Relay/Scenes/ActivityView/RelayActivityViewController.swift
@@ -71,6 +71,7 @@ extension RelayActivityViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let readingViewController = RelayReadingViewController()
         readingViewController.requestStory(stories[indexPath.row])
+        readingViewController.hidesBottomBarWhenPushed = true
         
         navigationController?.pushViewController(readingViewController, animated: true)
     }

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -89,6 +89,7 @@ extension RelayBrowsingViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let readingViewController = RelayReadingViewController()
         readingViewController.requestStory(stories[indexPath.row])
+        readingViewController.hidesBottomBarWhenPushed = true
         
         navigationController?.pushViewController(readingViewController, animated: true)
     }

--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -78,7 +78,9 @@ class RelayMainViewController: UIViewController {
             }
             
             let relayReadingViewController = RelayReadingViewController()
+            relayReadingViewController.hidesBottomBarWhenPushed = true
             relayReadingViewController.requestStory(story)
+            
             self?.navigationController?.pushViewController(relayReadingViewController, animated: true)
         }
         

--- a/Relay/Relay/Scenes/TabBarController.swift
+++ b/Relay/Relay/Scenes/TabBarController.swift
@@ -70,6 +70,8 @@ class TabBarController: UITabBarController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
         let isFirst = checkIsFirst()
         let isLogin = checkIsLoggedIn()
         DispatchQueue.main.asyncAfter(deadline: .now().advanced(by: .seconds(0))) { [weak self] in


### PR DESCRIPTION
## 작업사항
Figma에 기획된 디자인에 맞추기 위해 RelayReadingViewController가 나타날 땐 하단의 탭바가 보이지 않도록 구현하였습니다.

|구현 영상|
|:---:|
|<img width= "300" alt="RelayReadingViewController" src="https://user-images.githubusercontent.com/83946704/204041426-7e232bc2-25de-45df-8968-730d1cd8bb9c.gif">|


## 이슈번호
- #94 

## 특이사항
- 초기엔 기능적인 구현이 필요하다 생각되 feat으로 브랜치와 라벨을 설정하였지만 design 관련에 더 맞는 구현내용이라 생각됩니다.

close #94 