### PR TITLE
[2022/11/29] feat/playList >> RelayWritingViewController에서 음악 선택시, 적용시, 닫을 때 플레이리스트 실행 구현

### DIFF
--- a/Relay/Relay.xcodeproj/project.pbxproj
+++ b/Relay/Relay.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		3265BA33290925DE00532CA4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3265BA32290925DE00532CA4 /* Assets.xcassets */; };
 		3265BA36290925DE00532CA4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3265BA34290925DE00532CA4 /* LaunchScreen.storyboard */; };
 		329918A0290A5D8800372C13 /* RelayLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3299189F290A5D8800372C13 /* RelayLoginViewController.swift */; };
-		329FA02C292CBE820063981A /* PlayList_1.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 329FA024292CBE810063981A /* PlayList_1.mp3 */; };
 		329FA02D292CBE820063981A /* PlayList_5.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 329FA025292CBE810063981A /* PlayList_5.mp3 */; };
 		329FA02E292CBE820063981A /* PlayList_3.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 329FA026292CBE810063981A /* PlayList_3.mp3 */; };
 		329FA02F292CBE820063981A /* PlayList_2.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 329FA027292CBE820063981A /* PlayList_2.mp3 */; };
@@ -27,6 +26,7 @@
 		329FA031292CBE820063981A /* PlayList_6.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 329FA029292CBE820063981A /* PlayList_6.mp3 */; };
 		329FA032292CBE820063981A /* PlayList_7.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 329FA02A292CBE820063981A /* PlayList_7.mp3 */; };
 		329FA033292CBE820063981A /* PlayList_8.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 329FA02B292CBE820063981A /* PlayList_8.mp3 */; };
+		329FA05B292F57180063981A /* PlayList_1.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 329FA05A292F57180063981A /* PlayList_1.mp3 */; };
 		32DA1B7F29123F7500C6FDC1 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DA1B7E29123F7500C6FDC1 /* DetailViewController.swift */; };
 		32DE2B0629164291005D1A85 /* RelayWritingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DE2B0529164291005D1A85 /* RelayWritingViewController.swift */; };
 		32DE2B0929190A7E005D1A85 /* WritingTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DE2B0829190A7E005D1A85 /* WritingTitleView.swift */; };
@@ -121,7 +121,6 @@
 		3265BA35290925DE00532CA4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		3265BA37290925DE00532CA4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3299189F290A5D8800372C13 /* RelayLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayLoginViewController.swift; sourceTree = "<group>"; };
-		329FA024292CBE810063981A /* PlayList_1.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = PlayList_1.mp3; sourceTree = "<group>"; };
 		329FA025292CBE810063981A /* PlayList_5.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = PlayList_5.mp3; sourceTree = "<group>"; };
 		329FA026292CBE810063981A /* PlayList_3.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = PlayList_3.mp3; sourceTree = "<group>"; };
 		329FA027292CBE820063981A /* PlayList_2.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = PlayList_2.mp3; sourceTree = "<group>"; };
@@ -129,6 +128,7 @@
 		329FA029292CBE820063981A /* PlayList_6.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = PlayList_6.mp3; sourceTree = "<group>"; };
 		329FA02A292CBE820063981A /* PlayList_7.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = PlayList_7.mp3; sourceTree = "<group>"; };
 		329FA02B292CBE820063981A /* PlayList_8.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = PlayList_8.mp3; sourceTree = "<group>"; };
+		329FA05A292F57180063981A /* PlayList_1.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = PlayList_1.mp3; sourceTree = "<group>"; };
 		32DA1B7E29123F7500C6FDC1 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		32DE2B0529164291005D1A85 /* RelayWritingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayWritingViewController.swift; sourceTree = "<group>"; };
 		32DE2B0829190A7E005D1A85 /* WritingTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingTitleView.swift; sourceTree = "<group>"; };
@@ -305,7 +305,7 @@
 		329FA017292CA97C0063981A /* BGM */ = {
 			isa = PBXGroup;
 			children = (
-				329FA024292CBE810063981A /* PlayList_1.mp3 */,
+				329FA05A292F57180063981A /* PlayList_1.mp3 */,
 				329FA027292CBE820063981A /* PlayList_2.mp3 */,
 				329FA026292CBE810063981A /* PlayList_3.mp3 */,
 				329FA028292CBE820063981A /* PlayList_4.mp3 */,
@@ -717,7 +717,6 @@
 			files = (
 				3265BA36290925DE00532CA4 /* LaunchScreen.storyboard in Resources */,
 				329FA033292CBE820063981A /* PlayList_8.mp3 in Resources */,
-				329FA02C292CBE820063981A /* PlayList_1.mp3 in Resources */,
 				329FA02D292CBE820063981A /* PlayList_5.mp3 in Resources */,
 				329FA030292CBE820063981A /* PlayList_4.mp3 in Resources */,
 				32F83527290FECC300E2CC4A /* ChangwonDangamAsac-Bold_0712.otf in Resources */,
@@ -725,6 +724,7 @@
 				329FA032292CBE820063981A /* PlayList_7.mp3 in Resources */,
 				3265BA33290925DE00532CA4 /* Assets.xcassets in Resources */,
 				329FA02F292CBE820063981A /* PlayList_2.mp3 in Resources */,
+				329FA05B292F57180063981A /* PlayList_1.mp3 in Resources */,
 				329FA02E292CBE820063981A /* PlayList_3.mp3 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Relay/Relay/Model/BGM.swift
+++ b/Relay/Relay/Model/BGM.swift
@@ -40,14 +40,14 @@ struct Playlist {
 //        bgm7 = BGM(id: 6, name: "로맨스 플레이리스트 제목", hashTag: "#로맨스  #슬픈  #상실감  #어제의_너,,", fileName: "PlayList_7")
 //        bgm8 = BGM(id: 7, name: "아포칼립스 플레이리스트 제목", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스", fileName: "PlayList_8")
         
-        bgm1 = BGM(id: 0, name: "미스테리 플레이리스트 제목", hashTag: "#미스테리 #범죄 #음산한", fileName: "PlayList_1")
-        bgm2 = BGM(id: 1, name: "공포 플레이리스트 제목", hashTag: "#공포 #호러 #음산한 #피아노", fileName: "PlayList_2")
-        bgm3 = BGM(id: 2, name: "스리럴 플레이리스트 제목", hashTag: "#미스테리 #스릴러", fileName: "PlayList_3")
-        bgm4 = BGM(id: 3, name: "모험 플레이리스트 제목", hashTag: "#판타지 #모험 #대항해시대 #해적 #극적인", fileName: "PlayList_4")
-        bgm5 = BGM(id: 4, name: "사랑 사극 플레이리스트 제목", hashTag: "#사극 #동양풍 #해금 #극적인 #슬픈", fileName: "PlayList_5")
-        bgm6 = BGM(id: 5, name: "슬픈 사극 플레이리스트 제목", hashTag: "#사극  #동양풍  #해금  #아련한", fileName: "PlayList_6")
-        bgm7 = BGM(id: 6, name: "로맨스 플레이리스트 제목", hashTag: "#로맨스  #슬픈  #상실감  #어제의_너,,", fileName: "PlayList_7")
-        bgm8 = BGM(id: 7, name: "아포칼립스 플레이리스트 제목", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스", fileName: "PlayList_8")
+        bgm1 = BGM(id: 0, name: "좀비 아포칼립스", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스", fileName: "PlayList_1")
+        bgm2 = BGM(id: 1, name: "이루어 질 수 없습니다", hashTag: "#사극 #동양풍 #해금 #아련한", fileName: "PlayList_2")
+        bgm3 = BGM(id: 2, name: "모험의 시작", hashTag: "#판타지 #모험 #대항해시대 #해적 #극적인", fileName: "PlayList_3")
+        bgm4 = BGM(id: 3, name: "안개 낀 숲", hashTag: "#미스테리 #범죄 #음산한 #추리", fileName: "PlayList_4")
+        bgm5 = BGM(id: 4, name: "다녀오겠습니다 어머니", hashTag: "#사극 #동양풍 #해금 #극적인 #슬픈", fileName: "PlayList_5")
+        bgm6 = BGM(id: 5, name: "범죄 준비", hashTag: "#범죄 #살인 #계획범죄 #미스테리 #추리", fileName: "PlayList_6")
+        bgm7 = BGM(id: 6, name: "어제의 너", hashTag: "#로맨스 #슬픈 #상실감 #이별 #그리움", fileName: "PlayList_7")
+        bgm8 = BGM(id: 7, name: "한 맺힌 저주", hashTag: "#호러 #귀신 #폐가 #음산한", fileName: "PlayList_8")
         
         list = [bgm1, bgm2, bgm3, bgm4, bgm5, bgm6, bgm7, bgm8]
     }

--- a/Relay/Relay/Model/BGM.swift
+++ b/Relay/Relay/Model/BGM.swift
@@ -9,9 +9,11 @@ import Foundation
 
 class BGM: Category {
     let hashTag: String
+    let fileName: String
     
-    init(id: Int, name: String, hashTag: String) {
+    init(id: Int, name: String, hashTag: String, fileName: String) {
         self.hashTag = hashTag
+        self.fileName = fileName
         super.init(id: id, name: name)
     }
 }
@@ -29,14 +31,14 @@ struct Playlist {
     let list: [BGM]
     
     init() {
-        bgm1 = BGM(id: 0, name: "미스테리 플레이리스트 제목", hashTag: "#미스테리 #범죄 #음산한")
-        bgm2 = BGM(id: 1, name: "공포 플레이리스트 제목", hashTag: "#공포 #호러 #음산한 #피아노")
-        bgm3 = BGM(id: 2, name: "스리럴 플레이리스트 제목", hashTag: "#미스테리 #스릴러")
-        bgm4 = BGM(id: 3, name: "모험 플레이리스트 제목", hashTag: "#판타지 #모험 #대항해시대 #해적 #극적인")
-        bgm5 = BGM(id: 4, name: "사랑 사극 플레이리스트 제목", hashTag: "#사극 #동양풍 #해금 #극적인 #슬픈")
-        bgm6 = BGM(id: 5, name: "슬픈 사극 플레이리스트 제목", hashTag: "#사극  #동양풍  #해금  #아련한")
-        bgm7 = BGM(id: 6, name: "로맨스 플레이리스트 제목", hashTag: "#로맨스  #슬픈  #상실감  #어제의_너,,")
-        bgm8 = BGM(id: 7, name: "아포칼립스 플레이리스트 제목", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스")
+        bgm1 = BGM(id: 0, name: "미스테리 플레이리스트 제목", hashTag: "#미스테리 #범죄 #음산한", fileName: "Playlist_01")
+        bgm2 = BGM(id: 1, name: "공포 플레이리스트 제목", hashTag: "#공포 #호러 #음산한 #피아노", fileName: "Playlist_02")
+        bgm3 = BGM(id: 2, name: "스리럴 플레이리스트 제목", hashTag: "#미스테리 #스릴러", fileName: "Playlist_03")
+        bgm4 = BGM(id: 3, name: "모험 플레이리스트 제목", hashTag: "#판타지 #모험 #대항해시대 #해적 #극적인", fileName: "Playlist_04")
+        bgm5 = BGM(id: 4, name: "사랑 사극 플레이리스트 제목", hashTag: "#사극 #동양풍 #해금 #극적인 #슬픈", fileName: "Playlist_05")
+        bgm6 = BGM(id: 5, name: "슬픈 사극 플레이리스트 제목", hashTag: "#사극  #동양풍  #해금  #아련한", fileName: "Playlist_06")
+        bgm7 = BGM(id: 6, name: "로맨스 플레이리스트 제목", hashTag: "#로맨스  #슬픈  #상실감  #어제의_너,,", fileName: "Playlist_07")
+        bgm8 = BGM(id: 7, name: "아포칼립스 플레이리스트 제목", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스", fileName: "Playlist_08")
         
         list = [bgm1, bgm2, bgm3, bgm4, bgm5, bgm6, bgm7, bgm8]
     }

--- a/Relay/Relay/Model/BGM.swift
+++ b/Relay/Relay/Model/BGM.swift
@@ -31,14 +31,14 @@ struct Playlist {
     let list: [BGM]
     
     init() {
-        bgm1 = BGM(id: 0, name: "미스테리 플레이리스트 제목", hashTag: "#미스테리 #범죄 #음산한", fileName: "Playlist_01")
-        bgm2 = BGM(id: 1, name: "공포 플레이리스트 제목", hashTag: "#공포 #호러 #음산한 #피아노", fileName: "Playlist_02")
-        bgm3 = BGM(id: 2, name: "스리럴 플레이리스트 제목", hashTag: "#미스테리 #스릴러", fileName: "Playlist_03")
-        bgm4 = BGM(id: 3, name: "모험 플레이리스트 제목", hashTag: "#판타지 #모험 #대항해시대 #해적 #극적인", fileName: "Playlist_04")
-        bgm5 = BGM(id: 4, name: "사랑 사극 플레이리스트 제목", hashTag: "#사극 #동양풍 #해금 #극적인 #슬픈", fileName: "Playlist_05")
-        bgm6 = BGM(id: 5, name: "슬픈 사극 플레이리스트 제목", hashTag: "#사극  #동양풍  #해금  #아련한", fileName: "Playlist_06")
-        bgm7 = BGM(id: 6, name: "로맨스 플레이리스트 제목", hashTag: "#로맨스  #슬픈  #상실감  #어제의_너,,", fileName: "Playlist_07")
-        bgm8 = BGM(id: 7, name: "아포칼립스 플레이리스트 제목", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스", fileName: "Playlist_08")
+        bgm1 = BGM(id: 0, name: "미스테리 플레이리스트 제목", hashTag: "#미스테리 #범죄 #음산한", fileName: "PlayList_01")
+        bgm2 = BGM(id: 1, name: "공포 플레이리스트 제목", hashTag: "#공포 #호러 #음산한 #피아노", fileName: "PlayList_02")
+        bgm3 = BGM(id: 2, name: "스리럴 플레이리스트 제목", hashTag: "#미스테리 #스릴러", fileName: "PlayList_03")
+        bgm4 = BGM(id: 3, name: "모험 플레이리스트 제목", hashTag: "#판타지 #모험 #대항해시대 #해적 #극적인", fileName: "PlayList_04")
+        bgm5 = BGM(id: 4, name: "사랑 사극 플레이리스트 제목", hashTag: "#사극 #동양풍 #해금 #극적인 #슬픈", fileName: "PlayList_05")
+        bgm6 = BGM(id: 5, name: "슬픈 사극 플레이리스트 제목", hashTag: "#사극  #동양풍  #해금  #아련한", fileName: "PlayList_06")
+        bgm7 = BGM(id: 6, name: "로맨스 플레이리스트 제목", hashTag: "#로맨스  #슬픈  #상실감  #어제의_너,,", fileName: "PlayList_07")
+        bgm8 = BGM(id: 7, name: "아포칼립스 플레이리스트 제목", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스", fileName: "PlayList_08")
         
         list = [bgm1, bgm2, bgm3, bgm4, bgm5, bgm6, bgm7, bgm8]
     }

--- a/Relay/Relay/Model/BGM.swift
+++ b/Relay/Relay/Model/BGM.swift
@@ -66,4 +66,15 @@ struct Playlist {
 
         return bgmHashTag
     }
+    
+    func getBGMFileName(id: Int) -> String {
+        var bgmFileName = "플레이리스트 파일이름 오류"
+        
+        for i in 0..<list.count {
+            if list[i].id == id {
+                bgmFileName = list[i].fileName
+            }
+        }
+        return bgmFileName
+    }
 }

--- a/Relay/Relay/Model/BGM.swift
+++ b/Relay/Relay/Model/BGM.swift
@@ -24,6 +24,7 @@ struct Playlist {
     let bgm5: BGM
     let bgm6: BGM
     let bgm7: BGM
+    let bgm8: BGM
     
     let list: [BGM]
     
@@ -35,8 +36,9 @@ struct Playlist {
         bgm5 = BGM(id: 4, name: "사랑 사극 플레이리스트 제목", hashTag: "#사극 #동양풍 #해금 #극적인 #슬픈")
         bgm6 = BGM(id: 5, name: "슬픈 사극 플레이리스트 제목", hashTag: "#사극  #동양풍  #해금  #아련한")
         bgm7 = BGM(id: 6, name: "로맨스 플레이리스트 제목", hashTag: "#로맨스  #슬픈  #상실감  #어제의_너,,")
+        bgm8 = BGM(id: 7, name: "아포칼립스 플레이리스트 제목", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스")
         
-        list = [bgm1, bgm2, bgm3, bgm4, bgm5, bgm6, bgm7]
+        list = [bgm1, bgm2, bgm3, bgm4, bgm5, bgm6, bgm7, bgm8]
     }
     
     func getBGMName(id: Int) -> String {

--- a/Relay/Relay/Model/BGM.swift
+++ b/Relay/Relay/Model/BGM.swift
@@ -31,14 +31,23 @@ struct Playlist {
     let list: [BGM]
     
     init() {
-        bgm1 = BGM(id: 0, name: "미스테리 플레이리스트 제목", hashTag: "#미스테리 #범죄 #음산한", fileName: "PlayList_01")
-        bgm2 = BGM(id: 1, name: "공포 플레이리스트 제목", hashTag: "#공포 #호러 #음산한 #피아노", fileName: "PlayList_02")
-        bgm3 = BGM(id: 2, name: "스리럴 플레이리스트 제목", hashTag: "#미스테리 #스릴러", fileName: "PlayList_03")
-        bgm4 = BGM(id: 3, name: "모험 플레이리스트 제목", hashTag: "#판타지 #모험 #대항해시대 #해적 #극적인", fileName: "PlayList_04")
-        bgm5 = BGM(id: 4, name: "사랑 사극 플레이리스트 제목", hashTag: "#사극 #동양풍 #해금 #극적인 #슬픈", fileName: "PlayList_05")
-        bgm6 = BGM(id: 5, name: "슬픈 사극 플레이리스트 제목", hashTag: "#사극  #동양풍  #해금  #아련한", fileName: "PlayList_06")
-        bgm7 = BGM(id: 6, name: "로맨스 플레이리스트 제목", hashTag: "#로맨스  #슬픈  #상실감  #어제의_너,,", fileName: "PlayList_07")
-        bgm8 = BGM(id: 7, name: "아포칼립스 플레이리스트 제목", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스", fileName: "PlayList_08")
+//        bgm1 = BGM(id: 0, name: "미스테리 플레이리스트 제목", hashTag: "#미스테리 #범죄 #음산한", fileName: "PlayList_1")
+//        bgm2 = BGM(id: 1, name: "공포 플레이리스트 제목", hashTag: "#공포 #호러 #음산한 #피아노", fileName: "PlayList_2")
+//        bgm3 = BGM(id: 2, name: "스리럴 플레이리스트 제목", hashTag: "#미스테리 #스릴러", fileName: "PlayList_3")
+//        bgm4 = BGM(id: 3, name: "모험 플레이리스트 제목", hashTag: "#판타지 #모험 #대항해시대 #해적 #극적인", fileName: "PlayList_4")
+//        bgm5 = BGM(id: 4, name: "사랑 사극 플레이리스트 제목", hashTag: "#사극 #동양풍 #해금 #극적인 #슬픈", fileName: "PlayList_5")
+//        bgm6 = BGM(id: 5, name: "슬픈 사극 플레이리스트 제목", hashTag: "#사극  #동양풍  #해금  #아련한", fileName: "PlayList_6")
+//        bgm7 = BGM(id: 6, name: "로맨스 플레이리스트 제목", hashTag: "#로맨스  #슬픈  #상실감  #어제의_너,,", fileName: "PlayList_7")
+//        bgm8 = BGM(id: 7, name: "아포칼립스 플레이리스트 제목", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스", fileName: "PlayList_8")
+        
+        bgm1 = BGM(id: 0, name: "미스테리 플레이리스트 제목", hashTag: "#미스테리 #범죄 #음산한", fileName: "PlayList_1")
+        bgm2 = BGM(id: 1, name: "공포 플레이리스트 제목", hashTag: "#공포 #호러 #음산한 #피아노", fileName: "PlayList_2")
+        bgm3 = BGM(id: 2, name: "스리럴 플레이리스트 제목", hashTag: "#미스테리 #스릴러", fileName: "PlayList_3")
+        bgm4 = BGM(id: 3, name: "모험 플레이리스트 제목", hashTag: "#판타지 #모험 #대항해시대 #해적 #극적인", fileName: "PlayList_4")
+        bgm5 = BGM(id: 4, name: "사랑 사극 플레이리스트 제목", hashTag: "#사극 #동양풍 #해금 #극적인 #슬픈", fileName: "PlayList_5")
+        bgm6 = BGM(id: 5, name: "슬픈 사극 플레이리스트 제목", hashTag: "#사극  #동양풍  #해금  #아련한", fileName: "PlayList_6")
+        bgm7 = BGM(id: 6, name: "로맨스 플레이리스트 제목", hashTag: "#로맨스  #슬픈  #상실감  #어제의_너,,", fileName: "PlayList_7")
+        bgm8 = BGM(id: 7, name: "아포칼립스 플레이리스트 제목", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스", fileName: "PlayList_8")
         
         list = [bgm1, bgm2, bgm3, bgm4, bgm5, bgm6, bgm7, bgm8]
     }

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -63,8 +63,8 @@ extension RelayBrowsingViewController: UIViewControllerTransitioningDelegate {
 }
 
 extension RelayBrowsingViewController: RelayCategoryDelegate {
-    func playMusic() {
-        print("ㅇ")
+    func playMusic(id: Int) {
+        print("")
     }
     
     

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -63,11 +63,6 @@ extension RelayBrowsingViewController: UIViewControllerTransitioningDelegate {
 }
 
 extension RelayBrowsingViewController: RelayCategoryDelegate {
-    func playMusic(id: Int) {
-        print("")
-    }
-    
-    
     func didApplyCategory(selectedCategory: Category) {
         self.selectedCategory = selectedCategory
         

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -63,6 +63,11 @@ extension RelayBrowsingViewController: UIViewControllerTransitioningDelegate {
 }
 
 extension RelayBrowsingViewController: RelayCategoryDelegate {
+    func playMusic() {
+        print("ㅇ")
+    }
+    
+    
     func didApplyCategory(selectedCategory: Category) {
         self.selectedCategory = selectedCategory
         

--- a/Relay/Relay/Scenes/Reusable/CategoryModal/CategoryModalPresentationController.swift
+++ b/Relay/Relay/Scenes/Reusable/CategoryModal/CategoryModalPresentationController.swift
@@ -12,6 +12,7 @@ class CategoryModalPresentationController: UIPresentationController {
     let shadowView: UIView!
     var tapGestureRecognizer: UITapGestureRecognizer = UITapGestureRecognizer()
     var check: Bool = false
+    weak var dismissDelegate: CategoryModalDismissDelegate?
     
     override init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?) {
         shadowView = UIView()
@@ -55,5 +56,10 @@ class CategoryModalPresentationController: UIPresentationController {
     
     @objc func dismissController() {
         self.presentedViewController.dismiss(animated: true, completion: nil)
+        dismissDelegate?.dismissByTouchingBackground()
     }
+}
+
+protocol CategoryModalDismissDelegate: AnyObject {
+    func dismissByTouchingBackground()
 }

--- a/Relay/Relay/Scenes/Reusable/CategoryView/RelayCategoryViewController.swift
+++ b/Relay/Relay/Scenes/Reusable/CategoryView/RelayCategoryViewController.swift
@@ -14,6 +14,7 @@ class RelayCategoryViewController: UIViewController {
     private var selectedCategory: Category?
     
     weak var delegate: RelayCategoryDelegate?
+    weak var playlistDelegate: RelayPlaylistCategoryDelegate?
     
     private lazy var categoryCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -75,7 +76,7 @@ extension RelayCategoryViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedCategory = categoryList[indexPath.row]
-        delegate?.playMusic(id: selectedCategory?.id ?? 0)
+        playlistDelegate?.playMusic(id: selectedCategory?.id ?? 0)
     }
 }
 
@@ -153,6 +154,8 @@ extension RelayCategoryViewController {
 
 protocol RelayCategoryDelegate: AnyObject {
     func didApplyCategory(selectedCategory: Category)
-    
+}
+
+protocol RelayPlaylistCategoryDelegate: AnyObject {
     func playMusic(id: Int)
 }

--- a/Relay/Relay/Scenes/Reusable/CategoryView/RelayCategoryViewController.swift
+++ b/Relay/Relay/Scenes/Reusable/CategoryView/RelayCategoryViewController.swift
@@ -75,7 +75,7 @@ extension RelayCategoryViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedCategory = categoryList[indexPath.row]
-        delegate?.playMusic()
+        delegate?.playMusic(id: selectedCategory?.id ?? 0)
     }
 }
 
@@ -154,5 +154,5 @@ extension RelayCategoryViewController {
 protocol RelayCategoryDelegate: AnyObject {
     func didApplyCategory(selectedCategory: Category)
     
-    func playMusic()
+    func playMusic(id: Int)
 }

--- a/Relay/Relay/Scenes/Reusable/CategoryView/RelayCategoryViewController.swift
+++ b/Relay/Relay/Scenes/Reusable/CategoryView/RelayCategoryViewController.swift
@@ -39,6 +39,7 @@ class RelayCategoryViewController: UIViewController {
         
         button.addTarget(self, action: #selector(dismissViewController), for: .touchUpInside)
         
+        
         return button
     }()
     

--- a/Relay/Relay/Scenes/Reusable/CategoryView/RelayCategoryViewController.swift
+++ b/Relay/Relay/Scenes/Reusable/CategoryView/RelayCategoryViewController.swift
@@ -74,6 +74,7 @@ extension RelayCategoryViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedCategory = categoryList[indexPath.row]
+        delegate?.playMusic()
     }
 }
 
@@ -151,4 +152,6 @@ extension RelayCategoryViewController {
 
 protocol RelayCategoryDelegate: AnyObject {
     func didApplyCategory(selectedCategory: Category)
+    
+    func playMusic()
 }

--- a/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
+++ b/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
@@ -249,7 +249,10 @@ class RelayWritingViewController: UIViewController, UICollectionViewDelegate {
 
 extension RelayWritingViewController: UIViewControllerTransitioningDelegate {
     func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
-        CategoryModalPresentationController(presentedViewController: presented, presenting: presenting)
+        let modal = CategoryModalPresentationController(presentedViewController: presented, presenting: presenting)
+        modal.dismissDelegate = self
+        
+        return modal
         }
 }
 
@@ -278,6 +281,16 @@ extension RelayWritingViewController: RelayPlaylistCategoryDelegate {
             } catch {
                 print(error)
             }
+        }
+    }
+}
+
+extension RelayWritingViewController: CategoryModalDismissDelegate {
+    func dismissByTouchingBackground() {
+        if let bgm = selectedCategory {
+            playMusic(id: bgm.id)
+        } else {
+            audioPlayer?.stop()
         }
     }
 }

--- a/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
+++ b/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
@@ -233,6 +233,7 @@ class RelayWritingViewController: UIViewController, UICollectionViewDelegate {
     override func viewWillDisappear(_ animated: Bool) {
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+        audioPlayer?.stop()
     }
 
     override func viewDidLoad() {
@@ -271,7 +272,6 @@ extension RelayWritingViewController: RelayPlaylistCategoryDelegate {
         let playlist = Playlist()
         let fileName = playlist.getBGMFileName(id: id)
         let url = Bundle.main.url(forResource: fileName, withExtension: "mp3")
-        print(fileName)
         
         if let url = url {
             do {

--- a/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
+++ b/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
@@ -265,9 +265,7 @@ extension RelayWritingViewController: RelayCategoryDelegate {
     func playMusic(id: Int) {
         let playlist = Playlist()
         let fileName = playlist.getBGMFileName(id: id)
-    
         let url = Bundle.main.url(forResource: fileName, withExtension: "mp3")
-        
         print(fileName)
         
         if let url = url {

--- a/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
+++ b/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
@@ -11,7 +11,7 @@ import AVFoundation
 
 class RelayWritingViewController: UIViewController, UICollectionViewDelegate {
     private var selectedCategory: BGM?
-    private var selectedEvenet: String?
+    private var selectedEvent: String?
     private var selectedTouch: Int?
     var audioPlayer: AVAudioPlayer?
     
@@ -430,7 +430,7 @@ extension RelayWritingViewController {
             return
         }
         
-        guard let event = selectedEvenet else {
+        guard let event = selectedEvent else {
             // TODO: 장르선택 없을경우 Alert 또는 알림구현 필요
             print("종목을 선택해주세요.")
             return
@@ -669,7 +669,7 @@ extension RelayWritingViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         switch collectionView {
         case eventCollectionView:
-            selectedEvenet = tagList[indexPath.row]
+            selectedEvent = tagList[indexPath.row]
         case touchCollectionView:
             selectedTouch = touchList[indexPath.row]
         default:

--- a/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
+++ b/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
@@ -262,17 +262,8 @@ extension RelayWritingViewController: RelayCategoryDelegate {
         }
     }
     
-    func playMusic() {
-        let url = Bundle.main.url(forResource: "PlayList_1", withExtension: "mp3")
-        if let url = url {
-            do {
-                audioPlayer = try AVAudioPlayer(contentsOf: url)
-                audioPlayer?.prepareToPlay()
-                audioPlayer?.play()
-            } catch {
-                print(error)
-            }
-        }
+    func playMusic(id: Int) {
+    
     }
 }
 

--- a/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
+++ b/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
@@ -263,7 +263,22 @@ extension RelayWritingViewController: RelayCategoryDelegate {
     }
     
     func playMusic(id: Int) {
+        let playlist = Playlist()
+        let fileName = playlist.getBGMFileName(id: id)
     
+        let url = Bundle.main.url(forResource: fileName, withExtension: "mp3")
+        
+        print(fileName)
+        
+        if let url = url {
+            do {
+                audioPlayer = try AVAudioPlayer(contentsOf: url)
+                audioPlayer?.prepareToPlay()
+                audioPlayer?.play()
+            } catch {
+                print(error)
+            }
+        }
     }
 }
 

--- a/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
+++ b/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
@@ -261,7 +261,9 @@ extension RelayWritingViewController: RelayCategoryDelegate {
             musicListButton.setTitle(selectedPlaylist.name, for: .normal)
         }
     }
-    
+}
+
+extension RelayWritingViewController: RelayPlaylistCategoryDelegate {
     func playMusic(id: Int) {
         let playlist = Playlist()
         let fileName = playlist.getBGMFileName(id: id)
@@ -386,6 +388,7 @@ extension RelayWritingViewController {
         modalViewController.modalPresentationStyle = .custom
         modalViewController.transitioningDelegate = self
         modalViewController.delegate = self
+        modalViewController.playlistDelegate = self
         
         present(modalViewController, animated: true)
     }

--- a/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
+++ b/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
@@ -10,7 +10,7 @@ import SnapKit
 import AVFoundation
 
 class RelayWritingViewController: UIViewController, UICollectionViewDelegate {
-    private var selectedCategory: Category?
+    private var selectedCategory: BGM?
     private var selectedEvenet: String?
     private var selectedTouch: Int?
     var audioPlayer: AVAudioPlayer?
@@ -255,7 +255,7 @@ extension RelayWritingViewController: UIViewControllerTransitioningDelegate {
 
 extension RelayWritingViewController: RelayCategoryDelegate {
     func didApplyCategory(selectedCategory: Category) {
-        self.selectedCategory = selectedCategory
+        self.selectedCategory = selectedCategory as? BGM
         
         if let selectedPlaylist = self.selectedCategory {
             musicListButton.setTitle(selectedPlaylist.name, for: .normal)
@@ -263,7 +263,16 @@ extension RelayWritingViewController: RelayCategoryDelegate {
     }
     
     func playMusic() {
-        
+        let url = Bundle.main.url(forResource: "PlayList_1", withExtension: "mp3")
+        if let url = url {
+            do {
+                audioPlayer = try AVAudioPlayer(contentsOf: url)
+                audioPlayer?.prepareToPlay()
+                audioPlayer?.play()
+            } catch {
+                print(error)
+            }
+        }
     }
 }
 

--- a/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
+++ b/Relay/Relay/Scenes/WritingView/RelayWritingViewController.swift
@@ -7,11 +7,13 @@
 
 import UIKit
 import SnapKit
+import AVFoundation
 
 class RelayWritingViewController: UIViewController, UICollectionViewDelegate {
     private var selectedCategory: Category?
     private var selectedEvenet: String?
     private var selectedTouch: Int?
+    var audioPlayer: AVAudioPlayer?
     
     private let closeButton: UIButton = {
         let button = UIButton(type: .custom)
@@ -258,6 +260,10 @@ extension RelayWritingViewController: RelayCategoryDelegate {
         if let selectedPlaylist = self.selectedCategory {
             musicListButton.setTitle(selectedPlaylist.name, for: .normal)
         }
+    }
+    
+    func playMusic() {
+        
     }
 }
 
@@ -642,7 +648,6 @@ extension RelayWritingViewController: UICollectionViewDelegateFlowLayout {
         }
     }
 }
-
 
 extension RelayWritingViewController: UICollectionViewDataSource {
     


### PR DESCRIPTION
## 작업사항
1. RelayWritingViewController에서 RelayCategoryViewController를 띄운 후 플레이리스트를 선택할 때 음악이 실행되도록 구현하였습니다.
2. RelayCategoryViewController에서 적용하기를 누르면 뷰가 닫힌 후에도 해당 음악이 계속해서 실행되도록 구현하였습니다.
3. RelayCategoryViewController에서 적용하기를 누르지 않고 뷰를 닫을 때(회색배경을 터치할 때)에는 이전에 선택되어있던 음악이 실행되거나 음악이 멈추도록 구현하였습니다.

## 이슈번호
- #84 

## 특이사항(Optional)
1. 플레이리스트가 실행될 모든 뷰에서의 음악 실행/일시정지 기능 구현이 필요합니다.

2. AVAudioPlayer가 첫 실행될 때 발생하는 로그에 대한 오류해결이 필요합니다.

|오류 로그|
|:---:|
|<img width="1049" alt="스크린샷 2022-11-29 오후 5 14 15" src="https://user-images.githubusercontent.com/83946704/204474964-1551fce7-abfd-4d24-a95c-6fc9384c1eb5.png">|

close #84 