### PR TITLE
[2022/12/02] Feat/tutorial again >> '튜토리얼 다시보기'용 온보딩 디자인 수정 및 연결

### DIFF
--- a/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
+++ b/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
@@ -137,14 +137,14 @@ extension RelayOnboardingViewController{
     
     @objc private func pressedSkipButton(_ sender: UIButton) {
         let toRelayLoginView = RelayLoginViewController()
-           toRelayLoginView.modalPresentationStyle = .fullScreen
-           present(toRelayLoginView, animated: false, completion: nil)
+        toRelayLoginView.modalPresentationStyle = .fullScreen
+        present(toRelayLoginView, animated: false, completion: nil)
     }
     
     @objc private func pressedStartButton(_ sender: UIButton) {
         let toRelayLoginView = RelayLoginViewController()
-           toRelayLoginView.modalPresentationStyle = .fullScreen
-           present(toRelayLoginView, animated: false, completion: nil)
+        toRelayLoginView.modalPresentationStyle = .fullScreen
+        present(toRelayLoginView, animated: false, completion: nil)
     }
     
     @objc private func pressedReturnButton(_ sender: UIButton) {

--- a/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
+++ b/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
@@ -71,6 +71,7 @@ class RelayOnboardingViewController: UICollectionViewController, UICollectionVie
         
         configureViewController()
         setupLayout()
+        setupButtonTitleLayout(.tutorial)
     }
     
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
+++ b/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
@@ -52,6 +52,20 @@ class RelayOnboardingViewController: UICollectionViewController, UICollectionVie
         return button
     }()
     
+    private let returnButton: UIButton = {
+        let button = UIButton()
+        
+        button.setTitle("돌아가기", for: .normal)
+        button.backgroundColor = .black
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 16
+        button.titleLabel?.font = UIFont(name: "SF Pro", size: 16)
+        button.addTarget(self, action: #selector(pressedReturnButton), for: .touchUpInside)
+        button.isHidden = true
+        
+        return button
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
+++ b/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
@@ -158,6 +158,10 @@ extension RelayOnboardingViewController{
            present(toRelayLoginView, animated: false, completion: nil)
     }
     
+    @objc private func pressedReturnButton(_ sender: UIButton) {
+        self.dismiss(animated: false, completion: nil)
+    }
+    
     func configureViewController() {
         collectionView.isPagingEnabled = true
         collectionView.backgroundColor = .white

--- a/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
+++ b/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
@@ -27,7 +27,7 @@ class RelayOnboardingViewController: UICollectionViewController, UICollectionVie
         return controller
     }()
     
-    private let skipButton: UIButton = {
+    let skipButton: UIButton = {
         let button = UIButton()
         
         button.setTitle("건너뛰기", for: .normal)
@@ -71,7 +71,7 @@ class RelayOnboardingViewController: UICollectionViewController, UICollectionVie
         
         configureViewController()
         setupLayout()
-        setupButtonTitleLayout(.tutorial)
+        setupButtonTitleLayout(.onboarding)
     }
     
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -167,7 +167,7 @@ extension RelayOnboardingViewController {
         case tutorial = "돌아가기"
     }
     
-    private func setupButtonTitleLayout(_ buttonType: ButtonType) {
+    func setupButtonTitleLayout(_ buttonType: ButtonType) {
         switch buttonType {
         case .tutorial:
             [

--- a/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
+++ b/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
@@ -27,7 +27,7 @@ class RelayOnboardingViewController: UICollectionViewController, UICollectionVie
         return controller
     }()
     
-    let skipButton: UIButton = {
+    private let skipButton: UIButton = {
         let button = UIButton()
         
         button.setTitle("건너뛰기", for: .normal)
@@ -171,10 +171,14 @@ extension RelayOnboardingViewController {
         switch buttonType {
         case .tutorial:
             [
+                skipButton,
                 returnButton
                 
             ].forEach { view.addSubview($0) }
             
+            skipButton.snp.makeConstraints {
+                $0.top.equalToSuperview().inset(-100.0)
+            }
             returnButton.snp.makeConstraints {
                 $0.bottom.equalToSuperview().inset(95.0)
                 $0.centerX.equalToSuperview()
@@ -183,7 +187,6 @@ extension RelayOnboardingViewController {
                 $0.width.equalTo(350.0)
                 $0.height.equalTo(56.0)
             }
-            
         default:
             [
                 skipButton,

--- a/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
+++ b/Relay/Relay/Scenes/OnboardingView/RelayOnboardingViewController.swift
@@ -108,11 +108,13 @@ class RelayOnboardingViewController: UICollectionViewController, UICollectionVie
         
         if currentPage != 2 {
             startButton.isHidden = true
+            returnButton.isHidden = true
             skipButton.isHidden = false
             pageControl.isHidden = false
         }
         else {
             startButton.isHidden = false
+            returnButton.isHidden = false
             skipButton.isHidden = true
             pageControl.isHidden = true
         }
@@ -122,24 +124,10 @@ class RelayOnboardingViewController: UICollectionViewController, UICollectionVie
 extension RelayOnboardingViewController{
     private func setupLayout(){
         [
-            skipButton,
-            startButton,
-            pageControl,
+            pageControl
             
         ].forEach { view.addSubview($0) }
         
-        skipButton.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(64.0)
-            $0.trailing.equalToSuperview().inset(20.0)
-        }
-        startButton.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(95.0)
-            $0.centerX.equalToSuperview()
-            $0.leading.equalToSuperview().inset(20.0)
-            $0.trailing.equalToSuperview().inset(20.0)
-            $0.width.equalTo(350.0)
-            $0.height.equalTo(56.0)
-        }
         pageControl.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(115.0)
             $0.centerX.equalToSuperview()
@@ -167,5 +155,53 @@ extension RelayOnboardingViewController{
         collectionView.backgroundColor = .white
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.register(RelayOnboardingViewCell.self, forCellWithReuseIdentifier: RelayOnboardingViewCell.reuseIdentifier)
+    }
+}
+
+extension RelayOnboardingViewController {
+    
+    enum ButtonType: String {
+        case real
+        case onboarding = "시작하기"
+        case tutorial = "돌아가기"
+    }
+    
+    private func setupButtonTitleLayout(_ buttonType: ButtonType) {
+        switch buttonType {
+        case .tutorial:
+            [
+                returnButton
+                
+            ].forEach { view.addSubview($0) }
+            
+            returnButton.snp.makeConstraints {
+                $0.bottom.equalToSuperview().inset(95.0)
+                $0.centerX.equalToSuperview()
+                $0.leading.equalToSuperview().inset(20.0)
+                $0.trailing.equalToSuperview().inset(20.0)
+                $0.width.equalTo(350.0)
+                $0.height.equalTo(56.0)
+            }
+            
+        default:
+            [
+                skipButton,
+                startButton
+                
+            ].forEach { view.addSubview($0) }
+            
+            skipButton.snp.makeConstraints {
+                $0.top.equalToSuperview().inset(64.0)
+                $0.trailing.equalToSuperview().inset(20.0)
+            }
+            startButton.snp.makeConstraints {
+                $0.bottom.equalToSuperview().inset(95.0)
+                $0.centerX.equalToSuperview()
+                $0.leading.equalToSuperview().inset(20.0)
+                $0.trailing.equalToSuperview().inset(20.0)
+                $0.width.equalTo(350.0)
+                $0.height.equalTo(56.0)
+            }
+        }
     }
 }

--- a/Relay/Relay/Scenes/SettingView/RelayAboutRelayViewController.swift
+++ b/Relay/Relay/Scenes/SettingView/RelayAboutRelayViewController.swift
@@ -48,6 +48,7 @@ class RelayAboutRelayViewController: UIViewController, UITableViewDelegate, UITa
                 let toRelayOnboardingView = RelayOnboardingViewController(collectionViewLayout: layout)
                 toRelayOnboardingView.modalPresentationStyle = .fullScreen
                 self.present(toRelayOnboardingView, animated: false, completion: nil)
+                toRelayOnboardingView.setupButtonTitleLayout(.tutorial)
             },
             SettingsOption(title: "오픈소스 라이선스", details: "", version: "") {
                 // 오픈소스 라이선스 뷰 연결

--- a/Relay/Relay/Scenes/SettingView/RelayAboutRelayViewController.swift
+++ b/Relay/Relay/Scenes/SettingView/RelayAboutRelayViewController.swift
@@ -44,8 +44,9 @@ class RelayAboutRelayViewController: UIViewController, UITableViewDelegate, UITa
         models.append(Section(title: "", details: "", version: "", options: [
             SettingsOption(title: "튜토리얼 다시보기", details: "", version: "") {
                 let layout = UICollectionViewFlowLayout()
-                layout.scrollDirection = .horizontal
                 let toRelayOnboardingView = RelayOnboardingViewController(collectionViewLayout: layout)
+                
+                layout.scrollDirection = .horizontal
                 toRelayOnboardingView.modalPresentationStyle = .fullScreen
                 self.present(toRelayOnboardingView, animated: false, completion: nil)
                 toRelayOnboardingView.setupButtonTitleLayout(.tutorial)

--- a/Relay/Relay/Scenes/SettingView/RelayAboutRelayViewController.swift
+++ b/Relay/Relay/Scenes/SettingView/RelayAboutRelayViewController.swift
@@ -43,7 +43,11 @@ class RelayAboutRelayViewController: UIViewController, UITableViewDelegate, UITa
     func relaySettingViewConfigure() {
         models.append(Section(title: "", details: "", version: "", options: [
             SettingsOption(title: "튜토리얼 다시보기", details: "", version: "") {
-                // 온보딩 뷰 연결
+                let layout = UICollectionViewFlowLayout()
+                layout.scrollDirection = .horizontal
+                let toRelayOnboardingView = RelayOnboardingViewController(collectionViewLayout: layout)
+                toRelayOnboardingView.modalPresentationStyle = .fullScreen
+                self.present(toRelayOnboardingView, animated: false, completion: nil)
             },
             SettingsOption(title: "오픈소스 라이선스", details: "", version: "") {
                 // 오픈소스 라이선스 뷰 연결


### PR DESCRIPTION
## 작업사항
설정 >> 튜토리얼 다시보기 뷰용 온보딩 로직을 구현하였습니다.
튜토리얼 뷰 용 버튼 디자인(건너뛰기 버튼, 돌아가기 버튼) 구현하였습니다. 
돌아가기 버튼 클릭 시 로그인뷰가 아닌 세팅뷰로 돌아오도록 구현하였습니다.

## 이슈번호
- #91 

## 특이사항(Optional)
특이사항이 있을 경우 작성해주세요.

close #91 
