### PR TITLE
[2022/12/07] feat/RelayReadingViewControllerWriterFiltering >> RelayReadingViewController의 완주게시글의 참여작가가 동일인물이 있을 시 걸러주는 기능 구현 

### DIFF
--- a/Relay/Relay/Scenes/ReadingView/Views/RelayReadingFinishFooterView.swift
+++ b/Relay/Relay/Scenes/ReadingView/Views/RelayReadingFinishFooterView.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 import SnapKit
-import Foundation
 
 class RelayReadingFinishFooterView: UIView {
     private lazy var backgroundView: UIView = {

--- a/Relay/Relay/Scenes/ReadingView/Views/RelayReadingFinishFooterView.swift
+++ b/Relay/Relay/Scenes/ReadingView/Views/RelayReadingFinishFooterView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SnapKit
+import Foundation
 
 class RelayReadingFinishFooterView: UIView {
     private lazy var backgroundView: UIView = {
@@ -119,5 +120,19 @@ extension RelayReadingFinishFooterView {
             $0.width.equalTo(81.0)
             $0.height.equalTo(56.0)
         }
+    }
+}
+
+extension RelayReadingFinishFooterView{
+    func uniqueElementsFrom<T: Hashable>(array: [T]) -> [T] {
+      var set = Set<T>()
+      let result = array.filter {
+        guard !set.contains($0) else {
+          return false
+        }
+        set.insert($0)
+        return true
+      }
+      return result
     }
 }

--- a/Relay/Relay/Scenes/ReadingView/Views/RelayReadingFinishFooterView.swift
+++ b/Relay/Relay/Scenes/ReadingView/Views/RelayReadingFinishFooterView.swift
@@ -84,7 +84,11 @@ extension RelayReadingFinishFooterView {
                 contributerText += (" · " + (relays[i].contributer.penname ?? "필명호출오류"))
             }
         }
-        penNameLabel.text = contributerText
+        let contributerArray = contributerText.split(separator: " · ")
+        let removeDuplicates = uniqueElementsFrom(array:contributerArray)
+        let returnContributerText = removeDuplicates.joined(separator: " · ")
+        
+        penNameLabel.text = returnContributerText
     }
     
     private func setupLayout() {


### PR DESCRIPTION
## 작업사항
<p align="center">
<img width="321" alt="스크린샷 2022-12-07 오전 12 40 01" src="https://user-images.githubusercontent.com/70955060/205956518-4b0349c8-a83d-4d55-917f-d8c3d8112962.png">
➡️
<img width="328" alt="스크린샷 2022-12-07 오전 12 41 52" src="https://user-images.githubusercontent.com/70955060/205956984-4d37d92e-3462-48cd-a4bc-2b4eb41b935d.png">
</p>
RelayReadingViewController의 완주게시글의 참여작가가 중복될 시 한 번만 표기하는 기능을 구현하였습니다.

## 이슈번호
- #108 

## 특이사항(Optional)
특이사항이 있을 경우 작성해주세요.

close #108 