### PR TITLE
[2022/12/08] fix/mainViewControllerAudio >> RelayMainViewController에서의 플레이리스트 재생오류 수정

### DIFF
--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -58,6 +58,7 @@ class RelayMainViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        observable.pageNumber = nil
         observable.nowPlayingPage = nil
         observable.playingPlaylistID = nil
         observable.stopMusic()
@@ -181,7 +182,7 @@ extension RelayMainViewController {
 class RelayMainViewControllerObservable: ObservableObject {
     var audioPlayer: AVAudioPlayer?
     
-    @Published var pageNumber: Int = 0
+    @Published var pageNumber: Int?
     @Published var nowPlayingPage: Int?
     @Published var playingPlaylistID: Int?
     

--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -90,18 +90,24 @@ class RelayMainViewController: UIViewController {
             }
             
             let relayReadingViewController = RelayReadingViewController()
+            relayReadingViewController.audioPlayer = self?.observable.audioPlayer
             
             if let playlistID = self?.observable.playingPlaylistID {
                 if let storyBGM = story?.bgm {
                     if storyBGM != playlistID {
+                        self?.observable.stopMusic()
                         self?.observable.playMusic(bgmID: storyBGM)
-                        relayReadingViewController.audioPlayer = self?.observable.audioPlayer
+                    } else {
+                        if let player = self?.observable.audioPlayer {
+                            if !player.isPlaying {
+                                self?.observable.playMusic(bgmID: playlistID)
+                            }
+                        }
                     }
                 }
             } else {
                 if let storyBGM = story?.bgm {
                         self?.observable.playMusic(bgmID: storyBGM)
-                        relayReadingViewController.audioPlayer = self?.observable.audioPlayer
                 }
             }
             

--- a/Relay/Relay/Scenes/MainView/Views/CardView.swift
+++ b/Relay/Relay/Scenes/MainView/Views/CardView.swift
@@ -36,11 +36,12 @@ struct CardView: View {
                                 if isPlaying {
                                     if page == observable.nowPlayingPage {
                                         observable.pauseMusic()
+                                        isPlaying = false
                                     } else {
-                                        observable.nowPlayingPage = nil
-                                        observable.stopMusic()
+                                        observable.nowPlayingPage = page
+                                        observable.playMusic(bgmID: story.bgm)
+                                        isPlaying = true
                                     }
-                                    isPlaying = false
                                 } else {
                                     if page == observable.nowPlayingPage {
                                         observable.playMusic()


### PR DESCRIPTION
## 작업사항
1. RelayMainViewController에서 한 플레이리스트(A)를 실행하고 다른 플레이리스트의 스토리(B)를 들어갔다가 나온 후 A 플레이리스트를 실행할 때 버튼을 두번 터치해야 실행이 되는 오류를 수정하였습니다.
2. RelayMainViewController에서 한 플레이리스트(A)를 실행하고 해당 플레이리스트(A)를 일시정지 한 그 스토리(A의 스토리)를 들어가면 플레이리스트가 실행되지 않는 오류를 수정하였습니다.

## 이슈번호
- #114 

close #114 