### PR TITLE
[2022/12/09] fix/relayReadingWriteView >> 이어쓰기를 완료하면 RelayReadingWriteView가 RelayReadingViewController의 최상단에 레이아웃이 깨져있는 오류 수정

### DIFF
--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -90,7 +90,6 @@ class RelayMainViewController: UIViewController {
             }
             
             let relayReadingViewController = RelayReadingViewController()
-            relayReadingViewController.audioPlayer = self?.observable.audioPlayer
             
             if let playlistID = self?.observable.playingPlaylistID {
                 if let storyBGM = story?.bgm {
@@ -111,6 +110,7 @@ class RelayMainViewController: UIViewController {
                 }
             }
             
+            relayReadingViewController.audioPlayer = self?.observable.audioPlayer
             relayReadingViewController.hidesBottomBarWhenPushed = true
             relayReadingViewController.requestStory(story)
             

--- a/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
+++ b/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
@@ -203,17 +203,17 @@ extension RelayReadingViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             textView.textColor = .relayGray
-            textView.text = "내용을 작성해주세요."
-        } else if textView.text == "내용을 작성해주세요." {
+            textView.text = readingWriteView.textViewPlaceHolder
+        } else if textView.text == readingWriteView.textViewPlaceHolder {
             textView.textColor = .relayBlack
             textView.text = nil
         }
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || textView.text == "내용을 작성해주세요." {
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || textView.text == readingWriteView.textViewPlaceHolder {
             textView.textColor = .relayGray
-            textView.text = "내용을 작성해주세요."
+            textView.text = readingWriteView.textViewPlaceHolder
             readingWriteView.textCountLabel.text = "0/500자"
         }
     }
@@ -342,7 +342,7 @@ extension RelayReadingViewController {
         lazy var alert = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
         lazy var action = UIAlertAction(title: "확인", style: .default)
         
-        guard let text = readingWriteView.writingTextView.text, text != "내용을 작성해주세요." else {
+        guard let text = readingWriteView.writingTextView.text, text != readingWriteView.textViewPlaceHolder else {
             alert.message = "내용이 있어야합니다."
             alert.addAction(action)
             present(alert, animated: true)
@@ -414,6 +414,9 @@ extension RelayReadingViewController {
         stackView.addArrangedSubview(readingFooterView)
         
         readingWriteView.configure(touchCount: relays.count + 2)
+        readingWriteView.writingTextView.text = readingWriteView.textViewPlaceHolder
+        readingWriteView.writingTextView.textColor = .relayGray
+        readingWriteView.writingTextView.selectedTextRange = nil
         
         readingWriteView.isHidden = true
         readingFooterView.isHidden = false

--- a/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
+++ b/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
@@ -415,6 +415,7 @@ extension RelayReadingViewController {
         
         readingWriteView.configure(touchCount: relays.count + 2)
         
+        readingWriteView.isHidden = true
         readingFooterView.isHidden = false
     }
     
@@ -433,6 +434,7 @@ extension RelayReadingViewController {
         stackView.removeArrangedSubview(readingFooterView)
         stackView.addArrangedSubview(readingWriteView)
         
+        readingWriteView.isHidden = false
         readingFooterView.isHidden = true
     }
     

--- a/Relay/Relay/Scenes/ReadingView/Views/RelayReadingWriteView.swift
+++ b/Relay/Relay/Scenes/ReadingView/Views/RelayReadingWriteView.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 
 class RelayReadingWriteView: UIView {
-    private let textViewPlaceHolder = "내용을 작성해주세요."
+    var textViewPlaceHolder = "내용을 작성해주세요."
     
     private lazy var touchCountLabel: UILabel = {
         let label = UILabel()


### PR DESCRIPTION
## 작업사항
1. 이어쓰기를 완료하면 RelayReadingWriteView가 RelayReadingViewController의 최상단에 레이아웃이 깨져있는 오류를 수정하였습니다.
2. 이어쓰기 완료 후 다시 이어쓰기(바통터치 버튼)를 하면 플레이스 홀더가 나타나도록 구현하였습니다.
3. RelayMainViewController에서 RelayReadingViewController로 들어갈 때 RelayReadingViewController의 음악버튼이 동작하지 않는 오류를 수정하였습니다.

## 이슈번호
- #120 

close #120