### PR TITLE
[2022/12/10] Feat/fixCardView >> 플레이리스트 제목을 해시태그로 수정

### DIFF
--- a/Relay/Relay/Model/BGM.swift
+++ b/Relay/Relay/Model/BGM.swift
@@ -40,14 +40,14 @@ struct Playlist {
 //        bgm7 = BGM(id: 6, name: "로맨스 플레이리스트 제목", hashTag: "#로맨스  #슬픈  #상실감  #어제의_너,,", fileName: "PlayList_7")
 //        bgm8 = BGM(id: 7, name: "아포칼립스 플레이리스트 제목", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스", fileName: "PlayList_8")
         
-        bgm1 = BGM(id: 0, name: "좀비 아포칼립스", hashTag: "#아포칼립스 #좀비 #세계멸망 #바이러스", fileName: "PlayList_1")
-        bgm2 = BGM(id: 1, name: "이루어 질 수 없습니다", hashTag: "#사극 #동양풍 #해금 #아련한", fileName: "PlayList_2")
-        bgm3 = BGM(id: 2, name: "모험의 시작", hashTag: "#판타지 #모험 #대항해시대 #해적 #극적인", fileName: "PlayList_3")
-        bgm4 = BGM(id: 3, name: "안개 낀 숲", hashTag: "#미스테리 #범죄 #음산한 #추리", fileName: "PlayList_4")
-        bgm5 = BGM(id: 4, name: "다녀오겠습니다 어머니", hashTag: "#사극 #동양풍 #해금 #극적인 #슬픈", fileName: "PlayList_5")
-        bgm6 = BGM(id: 5, name: "범죄 준비", hashTag: "#범죄 #살인 #계획범죄 #미스테리 #추리", fileName: "PlayList_6")
-        bgm7 = BGM(id: 6, name: "어제의 너", hashTag: "#로맨스 #슬픈 #상실감 #이별 #그리움", fileName: "PlayList_7")
-        bgm8 = BGM(id: 7, name: "한 맺힌 저주", hashTag: "#호러 #귀신 #폐가 #음산한", fileName: "PlayList_8")
+        bgm1 = BGM(id: 0, name: "좀비 아포칼립스", hashTag: "#긴장되는", fileName: "PlayList_1")
+        bgm2 = BGM(id: 1, name: "이루어 질 수 없습니다", hashTag: "#애절한", fileName: "PlayList_2")
+        bgm3 = BGM(id: 2, name: "모험의 시작", hashTag: "#극적인", fileName: "PlayList_3")
+        bgm4 = BGM(id: 3, name: "안개 낀 숲", hashTag: "#고조되는", fileName: "PlayList_4")
+        bgm5 = BGM(id: 4, name: "다녀오겠습니다 어머니", hashTag: "#그리운", fileName: "PlayList_5")
+        bgm6 = BGM(id: 5, name: "범죄 준비", hashTag: "#미스테리한", fileName: "PlayList_6")
+        bgm7 = BGM(id: 6, name: "어제의 너", hashTag: "#아련한", fileName: "PlayList_7")
+        bgm8 = BGM(id: 7, name: "한 맺힌 저주", hashTag: "#으스스한", fileName: "PlayList_8")
         
         list = [bgm1, bgm2, bgm3, bgm4, bgm5, bgm6, bgm7, bgm8]
     }

--- a/Relay/Relay/Scenes/MainView/Views/CardView.swift
+++ b/Relay/Relay/Scenes/MainView/Views/CardView.swift
@@ -14,8 +14,9 @@ struct CardView: View {
     let story: Story
     let page: Int
     let playlist = Playlist()
-
+    
     var body: some View {
+        
         Rectangle()
             .overlay {
                 ZStack{
@@ -24,11 +25,10 @@ struct CardView: View {
                     
                     VStack(spacing: 0){
                         HStack(spacing: 0){
-                            Text(playlist.getBGMName(id: story.bgm))
-                                .font(.title2)
+                            Text("\(Image(systemName: "music.note")) \(playlist.getBGMHashTag(id: story.bgm))")
+                                .font(.system(size: 17))
                                 .bold()
                                 .foregroundColor(.white)
-                                .padding(.top, 25)
                             
                             Spacer()
                             
@@ -56,15 +56,9 @@ struct CardView: View {
                                     .foregroundColor(.white)
                                     .font(.system(size: 32))
                             }
-                            .padding(.top, 25)
                         }
-                        HStack(spacing: 0){
-                            Text(playlist.getBGMHashTag(id: story.bgm))
-                                .foregroundColor(.white)
-                                .font(.system(size: 13))
-                                .padding(.top, 4)
-                            Spacer()
-                        }
+                        .padding(.top, 25)
+                        
                         Spacer()
                         HStack(spacing: 0){
                             Text("바통을 이어받으세요")
@@ -105,4 +99,5 @@ struct CardView: View {
                 }
             }
     }
+    
 }


### PR DESCRIPTION
## 작업사항
1. 플레이리스트별 해시태그 변경했습니다.
2. 메인뷰 플레이리스트 제목 파트에 제목을 해시태그로 수정했습니다.

<img width="200" alt="스크린샷 2022-12-10 오전 2 50 29" src="https://user-images.githubusercontent.com/83203198/206763576-c7c7f5d0-dfbc-441e-b7e3-35cd4262c937.png">

## 이슈번호
#116 

## 특이사항(Optional)
1. Issue 새로 생성하지 않고 Eve가 생성해놓은거 사용하였습니다.

close #116 