### PR TITLE
[2022/12/12] fix/relayBrowsingVieweStatusLabel >> 새로운 릴레이 작성 후 RelayBrowsingViewController에서 각 셀들의 '달리는중', '완주'의 색상이 뒤바뀌게 나타나는 오류 수정

### DIFF
--- a/Relay/Relay/Scenes/Reusable/RelayListView/RelayListCollectionViewCell.swift
+++ b/Relay/Relay/Scenes/Reusable/RelayListView/RelayListCollectionViewCell.swift
@@ -16,10 +16,8 @@ class RelayListCollectionViewCell: UICollectionViewCell {
     private lazy var statusLabel: BasePaddingLabel = {
         let label = BasePaddingLabel()
         label.setFont(.caption2)
-        label.textColor = .white
         
         label.clipsToBounds = true
-        label.backgroundColor = .relayPink1
         label.layer.cornerRadius = 12.0
         
         return label
@@ -76,6 +74,8 @@ extension RelayListCollectionViewCell {
             statusLabel.backgroundColor = .systemBackground
         } else {
             statusLabel.text = "달리는중"
+            statusLabel.textColor = .white
+            statusLabel.backgroundColor = .relayPink1
         }
         
         stepCountLabel.text = "\(stepCount)/\(stepLimit) 터치"


### PR DESCRIPTION
## 작업사항
새로운 릴레이 작성 후 RelayBrowsingViewController에서 각 셀들의 '달리는중', '완주'의 색상이 뒤바뀌게 나타나는 오류를 수정하였습니다.

|수정 이미지|
|:---:|
|<img width="300" alt="" src="https://user-images.githubusercontent.com/83946704/206911907-567fe9cb-92ff-49f4-a78c-198a601dfc20.png">|

## 이슈번호
- #132 

close #132 