### PR TITLE
[2022/12/11] Fix/mainVCRecommendHeartCountErrorFix >> MainVC와 ReadingVC를 오갈 때 발생하는 하트수 오류 해결

### DIFF
--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -62,6 +62,8 @@ class RelayMainViewController: UIViewController {
         observable.nowPlayingPage = nil
         observable.playingPlaylistID = nil
         observable.stopMusic()
+        
+        recommend = mockRecommend.recommend
     }
     
     override func viewDidLoad() {

--- a/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
+++ b/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
@@ -428,8 +428,6 @@ extension RelayReadingViewController {
             if story.user_liked {
                 print("좋아요 해제")
                 let image = UIImage(systemName: "heart")
-                readingFooterView.likeButton.setImage(image, for: .normal)
-                readingFinishFooterView.likeButton.setImage(image, for: .normal)
                 
                 for i in 0..<mockStory.allList.count {
                     if mockStory.allList[i].id == story.id {
@@ -442,17 +440,21 @@ extension RelayReadingViewController {
                         
                         mockStory.allList[i].user_liked.toggle()
                         self.story?.user_liked.toggle()
-                        mockRecommend.recommend.story1.user_liked.toggle()
+                        
+                        mockRecommend.recommend.story1.user_liked = mockStory.allList[0].user_liked
+                        mockRecommend.recommend.story2.user_liked = mockStory.allList[1].user_liked
+                        mockRecommend.recommend.story3.user_liked = mockStory.allList[2].user_liked
                         
                         readingFooterView.likeButton.setTitle("\(self.story!.like_count)", for: .normal)
                         readingFinishFooterView.likeButton.setTitle("\(self.story!.like_count)", for: .normal)
+
+                        readingFooterView.likeButton.setImage(image, for: .normal)
+                        readingFinishFooterView.likeButton.setImage(image, for: .normal)
                     }
                 }
             } else {
                 print("좋아요 추가")
                 let image = UIImage(systemName: "heart.fill")
-                readingFooterView.likeButton.setImage(image, for: .normal)
-                readingFinishFooterView.likeButton.setImage(image, for: .normal)
                 
                 for i in 0..<mockStory.allList.count {
                     if mockStory.allList[i].id == story.id {
@@ -465,10 +467,16 @@ extension RelayReadingViewController {
                         
                         mockStory.allList[i].user_liked.toggle()
                         self.story?.user_liked.toggle()
-                        mockRecommend.recommend.story1.user_liked.toggle()
+                        
+                        mockRecommend.recommend.story1.user_liked = mockStory.allList[0].user_liked
+                        mockRecommend.recommend.story2.user_liked = mockStory.allList[1].user_liked
+                        mockRecommend.recommend.story3.user_liked = mockStory.allList[2].user_liked
                         
                         readingFooterView.likeButton.setTitle("\(self.story!.like_count)", for: .normal)
                         readingFinishFooterView.likeButton.setTitle("\(self.story!.like_count)", for: .normal)
+                        
+                        readingFooterView.likeButton.setImage(image, for: .normal)
+                        readingFinishFooterView.likeButton.setImage(image, for: .normal)
                         
                     }
                 }

--- a/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
+++ b/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
@@ -430,14 +430,19 @@ extension RelayReadingViewController {
                 let image = UIImage(systemName: "heart")
                 readingFooterView.likeButton.setImage(image, for: .normal)
                 readingFinishFooterView.likeButton.setImage(image, for: .normal)
+                
                 for i in 0..<mockStory.allList.count {
                     if mockStory.allList[i].id == story.id {
-                        
                         mockStory.allList[i].like_count -= 1
                         self.story?.like_count -= 1
                         
+                        mockRecommend.recommend.story1.like_count = mockStory.allList[0].like_count
+                        mockRecommend.recommend.story2.like_count = mockStory.allList[1].like_count
+                        mockRecommend.recommend.story3.like_count = mockStory.allList[2].like_count
+                        
                         mockStory.allList[i].user_liked.toggle()
                         self.story?.user_liked.toggle()
+                        mockRecommend.recommend.story1.user_liked.toggle()
                         
                         readingFooterView.likeButton.setTitle("\(self.story!.like_count)", for: .normal)
                         readingFinishFooterView.likeButton.setTitle("\(self.story!.like_count)", for: .normal)
@@ -448,17 +453,23 @@ extension RelayReadingViewController {
                 let image = UIImage(systemName: "heart.fill")
                 readingFooterView.likeButton.setImage(image, for: .normal)
                 readingFinishFooterView.likeButton.setImage(image, for: .normal)
+                
                 for i in 0..<mockStory.allList.count {
                     if mockStory.allList[i].id == story.id {
-                        
                         mockStory.allList[i].like_count += 1
                         self.story?.like_count += 1
+                        
+                        mockRecommend.recommend.story1.like_count = mockStory.allList[0].like_count
+                        mockRecommend.recommend.story2.like_count = mockStory.allList[1].like_count
+                        mockRecommend.recommend.story3.like_count = mockStory.allList[2].like_count
+                        
+                        mockStory.allList[i].user_liked.toggle()
+                        self.story?.user_liked.toggle()
+                        mockRecommend.recommend.story1.user_liked.toggle()
                         
                         readingFooterView.likeButton.setTitle("\(self.story!.like_count)", for: .normal)
                         readingFinishFooterView.likeButton.setTitle("\(self.story!.like_count)", for: .normal)
                         
-                        mockStory.allList[i].user_liked.toggle()
-                        self.story?.user_liked.toggle()
                     }
                 }
             }


### PR DESCRIPTION
## 작업사항
- ReadingVC에서 하트수 변경 후 MainVC로 이동할 시 하트 수 변경이 적용되지 않는 오류를 해결합니다
- 하트 클릭 시 mockRecommend의 like_count와 user_liked 수도 함께 변화하도록 구현합니다.
- MainVC에서 새로운 mockRecommend 데이터를 불러오도록 설정합니다.

## 이슈번호
- #135

## 특이사항(Optional)
특이사항이 있을 경우 작성해주세요.

close #135 