### PR TITLE
[2022/12/12] feat/mockStoryFilterAndDataConnection >> MockStory에 달리는중/완주, 최신순/오래된순/추천순, 카테고리별, 내가 시작한/참여한/좋아요한 Story 제공 필터기능 구현 및 해당 View 연결 구현

### DIFF
--- a/Relay/Relay/Model/MockData/MockRelay.swift
+++ b/Relay/Relay/Model/MockData/MockRelay.swift
@@ -24,7 +24,7 @@ struct MockRelay {
             Relay(
                 contributer: mockUser.curry,
             content: "그 날은 다른 날과 다름없는 날이었다. 그냥 아침에 계란 후라이 한 장을 더 먹었다는 점만 다를 뿐. 내가 이런 일에 휘말리게 될 줄은 추호도 생각하지 못 했다.",
-            created_time: 202211212105
+            created_time: 202212102100
         ),
             Relay(
                 contributer: mockUser.changBro,
@@ -33,7 +33,7 @@ struct MockRelay {
                 
 갑자기 창밖에서 유리가 깨지는 소리가 들렸다. 26남 이창형. 소리가 궁금해 마당으로 다가간다.
 """,
-            created_time: 202211212110
+            created_time: 202212102100
         ),
             Relay(
                 contributer: mockUser.eve,
@@ -43,19 +43,19 @@ struct MockRelay {
 “무슨일 있으신가요?? 뭐야!!”
 
 """,
-            created_time: 202211212115
+            created_time: 202212102100
         ),    Relay(
             contributer: mockUser.curry,
             content: "칼로 찌르듯 날카로운 비명이 내 귀를 훑고 지나갔다. 그 곳에는 마치 선악과를 먹은 태초의 이브처럼 범죄에 빠질 듯한 프레셔를 뿜고 있는 사람이 있었다. 이 사람, 내거다. 단박에 내 머릿속을 스쳐 지나갔다. 이 사람은 지금 이 곳에 왜 있는거지? 설명할 수 없는 의문점만이 떠올랐다.",
-            created_time: 202211212120
+            created_time: 202212102100
         ), Relay(
             contributer: mockUser.curry,
             content: "나는 조심스럽게 다가가 그 사람의 얼굴을 봤다.",
-            created_time: 202211212120
+            created_time: 202212102100
         ), Relay(
             contributer: mockUser.curry,
             content: "앗. 여성분인줄 알았지만 자세히 다가가서 보니 남자였다. 하지만 이 사람, 내거다.",
-            created_time: 202211212120
+            created_time: 202212102100
         ), Relay(
             contributer: mockUser.curry,
             content: """
@@ -63,7 +63,7 @@ struct MockRelay {
             
 “혹시… 괜찮으신가요? 무슨일 있으세요?”
 """,
-            created_time: 202211212120
+            created_time: 202212102100
         ), Relay(
             contributer: mockUser.curry,
             content: """
@@ -71,7 +71,7 @@ struct MockRelay {
 
 “안녕하세요, 27남 이재웅입니다. 깔끔하고 매너있는 스타일입니다.”
 """,
-            created_time: 202211212120
+            created_time: 202212102100
         ),
             Relay(
                 contributer: mockUser.curry,
@@ -84,7 +84,7 @@ struct MockRelay {
 
 지금이구나. 여자친구를 만나 느끼지 못했던, 내가 지금 울부짖고 소리쳤던 이유가 이거였구나. 이사람을 만나기 위해서였구나…
 """,
-                created_time: 202211212120
+                created_time: 202212102100
             ), Relay(
                 contributer: mockUser.curry,
                 content: """
@@ -92,19 +92,19 @@ struct MockRelay {
 
 26남 이창형의 눈을 바라볼수록 익숙한 감정이 떠올랐다. 어쩌면 우린.. 이어질 수 없는 사이인것만 같았다.
 """,
-                created_time: 202211212120
+                created_time: 202212102100
             ), Relay(
                 contributer: mockUser.curry,
                 content: """
 이런 생각을 하던 도중 식장에서 여러 명의 찢어질듯한 비명소리가 들렸다. 고개를 돌린 나는, 오늘 나와 웨딩마치를 올릴 예정이었던 나의 신부와 눈이 마주쳤다. 하지만 내가 알던 그녀가 아니다. 그녀의 피인지 남의 피인지 모를 피를 온 몸에 묻히고 있는 그녀는 괴상한 소리를 내며 내쪽으로 다가오고 있다.
 """,
-                created_time: 202211212120
+                created_time: 202212102100
             ) , Relay(
                 contributer: mockUser.curry,
                 content: """
 그녀와 드디어 마주쳤다.
 """,
-                created_time: 202211212120
+                created_time: 202212102100
             ) , Relay(
                 contributer: mockUser.curry,
                 content: """
@@ -112,7 +112,7 @@ struct MockRelay {
 
 재웅이 말하는 순간 영희가 재웅의 목을 물어 뜯었다.
 """,
-                created_time: 202211212120
+                created_time: 202212102100
             ) , Relay(
                 contributer: mockUser.curry,
                 content: """
@@ -126,7 +126,7 @@ struct MockRelay {
 
 여긴 어디지?
 """,
-                created_time: 202211212120
+                created_time: 202212102100
             )
         ]
         
@@ -136,13 +136,13 @@ struct MockRelay {
                 content: """
 혹시 나 말고 다른 사람이 있는지 주위를 둘러보기로 결심했다
 """,
-                created_time: 202211212205
+                created_time: 202212092100
             ), Relay(
                 contributer: mockUser.curry,
                 content: """
 처음에는 아무것도 보이지 않았지만 손을 더듬어 열려있는 공간을 찾아 나아갔다. 미끌거림을 헤쳐나가자 문 손잡이가 잡혔고 힘주어 밀어 나가봤다
 """,
-                created_time: 202211212205
+                created_time: 202212092100
             ), Relay(
                 contributer: mockUser.curry,
                 content: """
@@ -151,34 +151,57 @@ struct MockRelay {
 여느때와 같이 시끄러운 알람소리와 함께 아침을 시작한다
 무료하다… 사는게 힘들다. 언제까지 백수로 지내야지.. 이렇게 살아선 안되겠다. 무언가 바뀌어야된다
 """,
-                created_time: 202211212205
+                created_time: 202212092100
             ), Relay(
                 contributer: mockUser.curry,
                 content: """
 갑자기 밖에서 누가 노크를 한다.
 똑똑똑
 """,
-                created_time: 202211212205
+                created_time: 202212092100
             ), Relay(
                 contributer: mockUser.curry,
                 content: """
 아들~ 엄마는 아들을 믿어~
 """,
-                created_time: 202211212205
+                created_time: 202212092100
             ), Relay(
                 contributer: mockUser.curry,
                 content: """
 문앞에 먹을거 놨으니까 꼭 챙겨먹고 아들 사랑해~~
 """,
-                created_time: 202211212205
+                created_time: 202212092100
             ), Relay(
                 contributer: mockUser.curry,
                 content: """
 엄마 어디가…?
 불안한 예감에 문을 열고 뛰쳐나갔다
 """,
-                created_time: 202211212205
-            )
+                created_time: 202212092100
+            ),
+            Relay(
+               contributer: mockUser.curry,
+               content: """
+문을 열어보니 아무도 없었다.
+
+아... 맞다...
+엄마 작년에 돌아가셨지..?
+
+내가 보고 들었던건 모두 환청과 환상이었다.
+""",
+               created_time: 202212092100
+           ),
+            Relay(
+               contributer: mockUser.curry,
+               content: """
+다시 침대로 돌아와 눕는다. 다시 눈을 감는다.
+
+어쩌면 내가 우주에서 홀로 남겨진 꿈을 꾼 것이
+
+지금의 내 현실과 비슷했기 때문에 아무렇지 않게 느꼈던 것은 아닐까
+""",
+               created_time: 202212092100
+           )
         ]
         
         story3Relay = [
@@ -195,7 +218,7 @@ struct MockRelay {
 
 그러다 문득, 어저께 택배로 시킨 라면이 도착했다는 문자가 왔던게 생각이 났다. 얼마나 갇혀있어야 하는 지도 모르는데, 일단 내 방 앞에 도착해 있을 라면을 가지고 들어오기로 결정했다.
 """,
-                created_time: 202211212205
+                created_time: 202212082100
             ),
             Relay(
                 contributer: mockUser.curry,
@@ -216,7 +239,7 @@ struct MockRelay {
 
 ‘아니, 이게 뭐야. 이거 왜이래…!’
 """,
-                created_time: 202211212210
+                created_time: 202212082100
             ),
             Relay(
                 contributer: mockUser.curry,
@@ -225,7 +248,7 @@ struct MockRelay {
 
 “지금 뉴스 봐봤자 소용 없어.”
 """,
-                created_time: 202211212215
+                created_time: 202212082100
             ),
             Relay(
                 contributer: mockUser.curry,
@@ -234,7 +257,7 @@ struct MockRelay {
 
 화가 난 나머지 티비를 박살냈다.
 """,
-                created_time: 202211212220
+                created_time: 202212082100
             )
         ]
         

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -47,6 +47,16 @@ struct MockStory {
         return finishStories
     }
     
+    func fetchNewerStories() -> [Story] {
+        var newerStories: [Story] = []
+        
+        newerStories = allList.sorted {
+            $0.created_time > $1.created_time
+        }
+        
+        return newerStories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -125,6 +125,18 @@ struct MockStory {
         return stories
     }
     
+    func fetchSFStories() -> [Story] {
+        var stories: [Story] = []
+        
+        for story in allList {
+            if story.genre == "추리" {
+                stories.append(story)
+            }
+        }
+        
+        return stories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -67,6 +67,16 @@ struct MockStory {
         return olderStories
     }
     
+    func fetchMostLikeStories() -> [Story] {
+        var mostLikeStories: [Story] = []
+        
+        mostLikeStories = allList.sorted {
+            $0.like_count > $1.like_count
+        }
+        
+        return mostLikeStories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -242,10 +242,10 @@ struct MockStory {
             bgm: 0,
             like_count: 2,
             step_limit: 20,
-            current_step: 4,
+            current_step: 15,
             finished: false,
             contributed_users: [mockUserResponse.curryResponse, mockUserResponse.changBroResponse, mockUserResponse.eveResponse],
-            created_time: 202211212100,
+            created_time: 202212102100,
             user_liked: true
         )
         
@@ -264,7 +264,7 @@ struct MockStory {
             current_step: 10,
             finished: true,
             contributed_users: [mockUserResponse.curryResponse],
-            created_time: 202211212200,
+            created_time: 202212092100,
             user_liked: true
         )
         
@@ -288,10 +288,10 @@ struct MockStory {
             bgm: 2,
             like_count: 5,
             step_limit: 30,
-            current_step: 4,
+            current_step: 5,
             finished: false,
             contributed_users: [mockUserResponse.curryResponse, mockUserResponse.changBroResponse, mockUserResponse.eveResponse],
-            created_time: 202211212300,
+            created_time: 202212082100,
             user_liked: false
         )
         
@@ -334,7 +334,7 @@ struct MockStory {
             original: mockUserResponse.changBroResponse,
             genre: "판타지",
             header: "판타지아",
-            title: "나 이창형, 때리다.",
+            title: "현실에선 취준생이 이세계에선?",
             content: "26남 이창형이였다. 그것은 바로 26 남 이창형인 것이다. 그렇기 때문에 26 남 이창형인 것이고 26살의 남자인 것이다. 그는 울산의 이창형이다. 그렇다.26남 이창형이였다. 그것은 바로 26 남 이창형인 것이다. 그렇기 때문에 26 남 이창형인 것이고 26살의 남자인 것이다. 그는 울산의 이창형이다. 그렇다.26남 이창형이였다. 그것은 바로 26 남 이창형인 것이다. 그렇기 때문에 26 남 이창형인 것이고 26살의 남자인 것이다. 그는 울산의 이창형이다. 그렇다.26남 이창형이였다. 그것은 바로 26 남 이창형인 것이다. 그렇기 때문에 26 남 이창형인 것이고 26살의 남자인 것이다. 그는 울산의 이창형이다. 그렇다.26남 이창형이였다. 그것은 바로 26 남 이창형인 것이다. 그렇기 때문에 26 남 이창형인 것이고 26살의 남자인 것이다. 그는 울산의 이창형이다. 그렇다.26남 이창형이였다. 그것은 바로 26 남 이창형인 것이다. 그렇기 때문에 26 남 이창형인 것이고 26살의 남자인 것이다. 그는 울산의 이창형이다. 그렇다.26남 이창형이였다. 그것은 바로 26 남 이창형인 것이다. 그렇기 때문에 26 남 이창형인 것이고 26살의 남자인 것이다. 그는 울산의 이창형이다. 그렇다.",
             bgm: 5,
             like_count: 5,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -125,7 +125,7 @@ struct MockStory {
         return stories
     }
     
-    func fetchSFStories() -> [Story] {
+    func fetchInferenceStories() -> [Story] {
         var stories: [Story] = []
         
         for story in allList {

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -185,6 +185,18 @@ struct MockStory {
         return stories
     }
     
+    func fetchUserStartedStories() -> [Story] {
+        var stories: [Story] = []
+        
+        for story in allList {
+            if story.original.penname == "커리" {
+                stories.append(story)
+            }
+        }
+        
+        return stories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -137,6 +137,18 @@ struct MockStory {
         return stories
     }
     
+    func fetchMartialArtsStories() -> [Story] {
+        var stories: [Story] = []
+        
+        for story in allList {
+            if story.genre == "무협" {
+                stories.append(story)
+            }
+        }
+        
+        return stories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -89,6 +89,18 @@ struct MockStory {
         return stories
     }
     
+    func fetchThrillerStories() -> [Story] {
+        var stories: [Story] = []
+        
+        for story in allList {
+            if story.genre == "스릴러/공포" {
+                stories.append(story)
+            }
+        }
+        
+        return stories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -215,8 +215,20 @@ struct MockStory {
         return stories
     }
     
+    func fetchUserLikedStories() -> [Story] {
+        var stories: [Story] = []
+        
+        for story in allList {
+            if story.user_liked {
+                stories.append(story)
+            }
+        }
+        
+        return stories
+    }
+    
     init() {
-        story1 = Story(
+            story1 = Story(
             id: 0,
             original: mockUserResponse.curryResponse,
             genre: "로맨스",

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -77,6 +77,18 @@ struct MockStory {
         return mostLikeStories
     }
     
+    func fetchRomanceStories() -> [Story] {
+        var stories: [Story] = []
+        
+        for story in allList {
+            if story.genre == "로맨스" {
+                stories.append(story)
+            }
+        }
+        
+        return stories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -161,6 +161,18 @@ struct MockStory {
         return stories
     }
     
+    func fetchGeneralStories() -> [Story] {
+        var stories: [Story] = []
+        
+        for story in allList {
+            if story.genre == "일반" {
+                stories.append(story)
+            }
+        }
+        
+        return stories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -173,6 +173,18 @@ struct MockStory {
         return stories
     }
     
+    func fetchETCStories() -> [Story] {
+        var stories: [Story] = []
+        
+        for story in allList {
+            if story.genre == "기타" {
+                stories.append(story)
+            }
+        }
+        
+        return stories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -21,6 +21,19 @@ struct MockStory {
     
     var allList: [Story]
     
+    func fetchRunningStories() -> [Story] {
+        let stories = allList
+        var runningStories: [Story] = []
+        
+        for story in stories {
+            if !story.finished {
+                runningStories.append(story)
+            }
+        }
+        
+        return runningStories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -149,6 +149,18 @@ struct MockStory {
         return stories
     }
     
+    func fetchHistoricalStories() -> [Story] {
+        var stories: [Story] = []
+        
+        for story in allList {
+            if story.genre == "시대극" {
+                stories.append(story)
+            }
+        }
+        
+        return stories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -197,6 +197,24 @@ struct MockStory {
         return stories
     }
     
+    func fetchUserParticipatedStories() -> [Story] {
+        var stories: [Story] = []
+        
+        for story in allList {
+            if story.original.penname != "커리" {
+                if let contributedUsers = story.contributed_users {
+                    for user in contributedUsers {
+                        if user.penname == "커리" {
+                            stories.append(story)
+                        }
+                    }
+                }
+            }
+        }
+        
+        return stories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -57,6 +57,16 @@ struct MockStory {
         return newerStories
     }
     
+    func fetchOlderStories() -> [Story] {
+        var olderStories: [Story] = []
+        
+        olderStories = allList.sorted {
+            $0.created_time < $1.created_time
+        }
+        
+        return olderStories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -113,6 +113,18 @@ struct MockStory {
         return stories
     }
     
+    func fetchSFStories() -> [Story] {
+        var stories: [Story] = []
+        
+        for story in allList {
+            if story.genre == "SF" {
+                stories.append(story)
+            }
+        }
+        
+        return stories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -101,6 +101,18 @@ struct MockStory {
         return stories
     }
     
+    func fetchFantasyStories() -> [Story] {
+        var stories: [Story] = []
+        
+        for story in allList {
+            if story.genre == "판타지" {
+                stories.append(story)
+            }
+        }
+        
+        return stories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Model/MockData/MockStory.swift
+++ b/Relay/Relay/Model/MockData/MockStory.swift
@@ -34,6 +34,19 @@ struct MockStory {
         return runningStories
     }
     
+    func fetchFinishStories() -> [Story] {
+        let stories = allList
+        var finishStories: [Story] = []
+        
+        for story in stories {
+            if story.finished {
+                finishStories.append(story)
+            }
+        }
+        
+        return finishStories
+    }
+    
     init() {
         story1 = Story(
             id: 0,

--- a/Relay/Relay/Scenes/ActivityView/RelayActivityViewController.swift
+++ b/Relay/Relay/Scenes/ActivityView/RelayActivityViewController.swift
@@ -54,7 +54,16 @@ class RelayActivityViewController: UIViewController {
         view.backgroundColor = .systemBackground
         
         //TODO: API를 통한 데이터호출로 구현필요
-        stories = mockStory.allList
+        switch type {
+        case .like:
+            stories = mockStory.fetchUserLikedStories()
+        case .participated:
+            stories = mockStory.fetchUserParticipatedStories()
+        case .started:
+            stories = mockStory.fetchUserStartedStories()
+        default:
+            stories = mockStory.allList
+        }
         
         relayListView.listCollectionView.delegate = self
         relayListView.listCollectionView.dataSource = self

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -251,10 +251,16 @@ extension RelayBrowsingViewController {
         switch sender.tag {
         case 0:
             currentHighlightedButton = .entire
+            stories = mockStory.allList
+            relayListView.listCollectionView.reloadData()
         case 1:
             currentHighlightedButton = .completed
+            stories = mockStory.fetchFinishStories()
+            relayListView.listCollectionView.reloadData()
         case 2:
             currentHighlightedButton = .running
+            stories = mockStory.fetchRunningStories()
+            relayListView.listCollectionView.reloadData()
         default:
             break
         }

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -91,6 +91,33 @@ extension RelayBrowsingViewController: RelayCategoryDelegate {
         } else {
             relayListView.listHeaderView?.listFilterButton.setTitle(selectedCategory.name, for: .normal)
         }
+        
+        switch selectedCategory.name {
+        case "전체":
+            stories = mockStory.fetchNewerStories()
+        case "로맨스":
+            stories = mockStory.fetchRomanceStories()
+        case "스릴러/공포":
+            stories = mockStory.fetchThrillerStories()
+        case "판타지":
+            stories = mockStory.fetchFantasyStories()
+        case "SF":
+            stories = mockStory.fetchSFStories()
+        case "추리":
+            stories = mockStory.fetchInferenceStories()
+        case "무협":
+            stories = mockStory.fetchMartialArtsStories()
+        case "시대극":
+            stories = mockStory.fetchHistoricalStories()
+        case "일반":
+            stories = mockStory.fetchGeneralStories()
+        case "기타":
+            stories = mockStory.fetchETCStories()
+        default:
+            stories = mockStory.fetchNewerStories()
+        }
+        
+        relayListView.listCollectionView.reloadData()
     }
 }
 

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -167,9 +167,9 @@ extension RelayBrowsingViewController {
         relayBrowsingHeaderView.completedTitleView.titleButton.tag = 1
         relayBrowsingHeaderView.runningTitleView.titleButton.tag = 2
         
-        relayBrowsingHeaderView.entireTitleView.titleButton.addTarget(self, action: #selector(touchButton), for: .touchUpInside)
-        relayBrowsingHeaderView.completedTitleView.titleButton.addTarget(self, action: #selector(touchButton), for: .touchUpInside)
-        relayBrowsingHeaderView.runningTitleView.titleButton.addTarget(self, action: #selector(touchButton), for: .touchUpInside)
+        relayBrowsingHeaderView.entireTitleView.titleButton.addTarget(self, action: #selector(touchHeaderViewButton), for: .touchUpInside)
+        relayBrowsingHeaderView.completedTitleView.titleButton.addTarget(self, action: #selector(touchHeaderViewButton), for: .touchUpInside)
+        relayBrowsingHeaderView.runningTitleView.titleButton.addTarget(self, action: #selector(touchHeaderViewButton), for: .touchUpInside)
         
         relayListView.listHeaderView?.listFilterButton.addTarget(self, action: #selector(touchListFilterButton), for: .touchUpInside)
     }
@@ -247,7 +247,7 @@ extension RelayBrowsingViewController {
         button.setAttributedTitle(NSAttributedString(titleAttribute), for: .normal)
     }
     
-    @objc private func touchButton(_ sender: UIButton) {
+    @objc private func touchHeaderViewButton(_ sender: UIButton) {
         switch sender.tag {
         case 0:
             currentHighlightedButton = .entire

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -11,9 +11,10 @@ import AVFoundation
 
 class RelayBrowsingViewController: UIViewController, UICollectionViewDelegate {
     var audioPlayer: AVAudioPlayer?
+    var stories: [Story] = []
     
     private var selectedCategory: Category?
-    var stories: [Story] = []
+    private var sortedType: SortedType = .newer
     
     private var currentHighlightedButton: ButtonName? {
         didSet {
@@ -44,7 +45,14 @@ class RelayBrowsingViewController: UIViewController, UICollectionViewDelegate {
         super.viewWillAppear(animated)
         
         //TODO: API를 통한 데이터호출로 변경
-        stories = mockStory.allList
+        switch sortedType {
+        case .newer:
+            stories = mockStory.fetchNewerStories()
+        case .older:
+            stories = mockStory.fetchOlderStories()
+        case .mostLike:
+            stories = mockStory.fetchMostLikeStories()
+        }
         relayListView.listCollectionView.reloadData()
         
         audioPlayer?.stop()
@@ -58,6 +66,7 @@ class RelayBrowsingViewController: UIViewController, UICollectionViewDelegate {
         
         currentHighlightedButton = .entire
         
+        relayListView.listHeaderView?.delegate = self
         relayListView.listCollectionView.delegate = self
         relayListView.listCollectionView.dataSource = self
         
@@ -82,6 +91,26 @@ extension RelayBrowsingViewController: RelayCategoryDelegate {
         } else {
             relayListView.listHeaderView?.listFilterButton.setTitle(selectedCategory.name, for: .normal)
         }
+    }
+}
+
+extension RelayBrowsingViewController: RelayListHeaderViewMenuDelegate {
+    func selectedNewerMenu() {
+        sortedType = .newer
+        stories = mockStory.fetchNewerStories()
+        relayListView.listCollectionView.reloadData()
+    }
+    
+    func selectedOlderMenu() {
+        sortedType = .older
+        stories = mockStory.fetchOlderStories()
+        relayListView.listCollectionView.reloadData()
+    }
+    
+    func selectedMostLikeMenu() {
+        sortedType = .mostLike
+        stories = mockStory.fetchMostLikeStories()
+        relayListView.listCollectionView.reloadData()
     }
 }
 
@@ -131,6 +160,12 @@ extension RelayBrowsingViewController {
         case entire = "전체"
         case running = "달리는중"
         case completed = "완주"
+    }
+    
+    enum SortedType {
+        case newer
+        case older
+        case mostLike
     }
     
     private func setupLayout() {

--- a/Relay/Relay/Scenes/ReadingView/Views/ReadingBodyView.swift
+++ b/Relay/Relay/Scenes/ReadingView/Views/ReadingBodyView.swift
@@ -57,7 +57,7 @@ extension ReadingBodyView: UICollectionViewDelegateFlowLayout {
         )
         
         if isReadingModeOn {
-            return CGSize(width: width, height: cellSize.height + 10.0)
+            return CGSize(width: width, height: cellSize.height + 25.0)
         } else {
             return CGSize(width: width, height: cellSize.height + 65.0)
         }

--- a/Relay/Relay/Scenes/Reusable/RelayListView/RelayListHeaderView.swift
+++ b/Relay/Relay/Scenes/Reusable/RelayListView/RelayListHeaderView.swift
@@ -9,15 +9,20 @@ import UIKit
 import SnapKit
 
 class RelayListHeaderView: UIView {
+    weak var delegate: RelayListHeaderViewMenuDelegate?
+    
     private lazy var menuItems: [UIAction] = {
         let latest = UIAction(title: "최신순", state: .on) { [weak self] _ in
             self?.checkMenu(.latest)
+            self?.delegate?.selectedNewerMenu()
         }
         let oldest = UIAction(title: "오래된순") { [weak self] _ in
             self?.checkMenu(.oldest)
+            self?.delegate?.selectedOlderMenu()
         }
         let popularity = UIAction(title: "인기순") { [weak self] _ in
             self?.checkMenu(.popularity)
+            self?.delegate?.selectedMostLikeMenu()
         }
         
         return [latest, oldest, popularity]
@@ -163,12 +168,15 @@ extension RelayListHeaderView {
         let menuItems: [UIAction] = {
             let latest = UIAction(title: "최신순", state: state.latest) { [weak self] _ in
                 self?.checkMenu(.latest)
+                self?.delegate?.selectedNewerMenu()
             }
             let oldest = UIAction(title: "오래된순", state: state.oldest) { [weak self] _ in
                 self?.checkMenu(.oldest)
+                self?.delegate?.selectedOlderMenu()
             }
             let popularity = UIAction(title: "인기순", state: state.popularity) { [weak self] _ in
                 self?.checkMenu(.popularity)
+                self?.delegate?.selectedMostLikeMenu()
             }
             
             return [latest, oldest, popularity]
@@ -180,3 +188,8 @@ extension RelayListHeaderView {
 
 }
 
+protocol RelayListHeaderViewMenuDelegate: AnyObject {
+    func selectedNewerMenu()
+    func selectedOlderMenu()
+    func selectedMostLikeMenu()
+}


### PR DESCRIPTION
## 작업사항
1. MockStory에 달리는중/완주, 최신순/오래된순/추천순, 카테고리별, 내가 시작한/참여한/좋아요한 Story 제공 필터기능 구현 및 해당 View 연결
2. MockStory 데이터 일부 수정
3. RelayReadingView에서 감상모드일때의 셀의 높이 수정

|구현 영상|
|:---:|
|<img width="300" alt="" src="https://user-images.githubusercontent.com/83946704/206918806-6ed515b1-b131-47fa-93b4-71a748a98094.gif">|


## 이슈번호
- #134 

## 특이사항(Optional)
1. 쇼케이스 데모용 로직입니다. 서버 API와 연결할 때에는 각 ViewController 별 호출로직이 변경될 수 있습니다.
2. 각 항목별로만 필터링이 가능합니다. 중복된 필터링은 불가능합니다. (ex : 달리는중 에서 오래된순 -> 불가능. 달리는중 or 오래된 순만 따로 가능)

close #134 