### PR TITLE
[2023/01/19] fix/relayReadingView/swipe >> RelayReadingViewController를 스와이프로 pop할 때 상위 ViewController의 NavigationBar가 사라지는 버그, NavigationBar BackButton이 흐릿하게 보이는 버그 수정

### DIFF
--- a/Relay/Relay/Scenes/ActivityView/RelayActivityViewController.swift
+++ b/Relay/Relay/Scenes/ActivityView/RelayActivityViewController.swift
@@ -44,6 +44,8 @@ class RelayActivityViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        setNavigationBar()
+        
         audioPlayer?.stop()
         audioPlayer = nil
     }
@@ -69,7 +71,6 @@ class RelayActivityViewController: UIViewController {
         relayListView.listCollectionView.dataSource = self
         
         setupButtonsLayout()
-        setNavigationBar()
         setupLayout()
     }
 }

--- a/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
+++ b/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
@@ -274,6 +274,9 @@ extension RelayReadingViewController: UIScrollViewDelegate {
 extension RelayReadingViewController {
     private func setupNavigationController() {
         navigationController?.navigationBar.isHidden = true
+        navigationController?.navigationBar.backIndicatorImage = UIImage()
+        navigationController?.navigationBar.backIndicatorTransitionMaskImage = UIImage()
+        navigationController?.navigationBar.topItem?.title = ""
     }
     
     private func setupCustomNavigationButton() {

--- a/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
+++ b/Relay/Relay/Scenes/ReadingView/RelayReadingViewController.swift
@@ -218,6 +218,12 @@ class RelayReadingViewController: UIViewController {
             $0.height.equalTo(readingBodyView.bodyCollectionView.collectionViewLayout.collectionViewContentSize.height)
         }
     }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        navigationController?.navigationBar.isHidden = false
+    }
 }
 
 extension RelayReadingViewController: UITextViewDelegate {


### PR DESCRIPTION
## 작업사항
1. RelayReadingViewController를 스와이프로 pop할 때 상위 ViewController의 NavigationBar가 사라지는 버그 수정
2. RelayReadingViewController를 pop할 때 NavigationBar BackButton이 흐릿하게 보이는 버그 수정

|버그수정 영상|
|:---:|
|<img width="300" alt="둘러보기(모달) - Figma" src="https://user-images.githubusercontent.com/83946704/213397040-d86cc5ea-7989-48f9-a909-108531fa79b9.gif">|

## 이슈번호
- #144 
- #62 

close #144 
close #62 