### PR TITLE
[2023/02/05] Fix/extension+date difference to string >> 소설 작성 시간 오류 수정 

### DIFF
--- a/Relay/Relay/Scenes/Extension+/Extension+Double.swift
+++ b/Relay/Relay/Scenes/Extension+/Extension+Double.swift
@@ -45,14 +45,17 @@ extension Double {
         } else if nowYear - year > 1 && nowMonth - month < 0 {
             dateDifference = "\(nowYear - year - 1)년 전"
             
+        } else if nowYear - year == 1 && nowMonth - month < 0 {
+            dateDifference = "\(nowMonth - month + 12)달 전"
+            
         } else if nowMonth - month > 0 && nowDay - day >= 0 {
             dateDifference = "\(nowMonth - month)달 전"
             
         } else if nowMonth - month > 1 && nowDay - day < 0 {
             dateDifference = "\(nowMonth - month - 1)달 전"
             
-        } else if nowMonth - month < 0 && nowDay - day >= 0 {
-            dateDifference = "\(nowMonth - month + 12)달 전"
+        } else if nowMonth - month == 1 && nowDay - day < 0 {
+            dateDifference = "\(nowDay - day + 31)일 전"
             
         } else if nowDay - day > 0 && nowHour - hour >= 0 {
             dateDifference = "\(nowDay - day)일 전"
@@ -60,23 +63,20 @@ extension Double {
         } else if nowDay - day > 1 && nowHour - hour < 0 {
             dateDifference = "\(nowDay - day - 1)일 전"
             
-        } else if nowDay - day < 0 {
-            dateDifference = "\(nowDay - day + 31)일 전"
+        } else if nowDay - day == 1 && nowHour - hour < 0 {
+            dateDifference = "\(nowHour - hour + 24)시간 전"
             
-        } else if nowHour - hour > 0 && nowMinute - minute >= 0  {
+        } else if nowHour - hour > 0 && nowMinute - minute >= 0 {
             dateDifference = "\(nowHour - hour)시간 전"
             
         } else if nowHour - hour > 1 && nowMinute - minute < 0 {
             dateDifference = "\(nowHour - hour - 1)시간 전"
             
-        } else if nowHour - hour < 0 {
-            dateDifference = "\(nowHour - hour + 24)시간 전"
+        }  else if nowHour - hour == 1 && nowMinute - minute < 0 {
+            dateDifference = "\(nowMinute - minute + 60)분 전"
             
         } else if nowMinute - minute > 0 {
             dateDifference = "\(nowMinute - minute)분 전"
-            
-        } else if nowHour - hour == 1 && nowMinute - minute < 0 {
-            dateDifference = "\(nowMinute - minute + 60)분 전"
             
         } else if (nowMinute - minute) == 0 {
             dateDifference = "방금 전"

--- a/Relay/Relay/Scenes/Extension+/Extension+Double.swift
+++ b/Relay/Relay/Scenes/Extension+/Extension+Double.swift
@@ -39,26 +39,52 @@ extension Double {
         
         var dateDifference: String?
         
-        if nowYear - year > 0 {
-            
+        if nowYear - year > 0 && nowMonth - month >= 0 {
             dateDifference = "\(nowYear - year)년 전"
-        } else if nowMonth - month > 0 {
             
+        } else if nowYear - year > 1 && nowMonth - month < 0 {
+            dateDifference = "\(nowYear - year - 1)년 전"
+            
+        } else if nowMonth - month > 0 && nowDay - day >= 0 {
             dateDifference = "\(nowMonth - month)달 전"
-        } else if nowDay - day > 0 {
             
+        } else if nowMonth - month > 1 && nowDay - day < 0 {
+            dateDifference = "\(nowMonth - month - 1)달 전"
+            
+        } else if nowMonth - month < 0 {
+            dateDifference = "\(nowMonth - month + 12)달 전"
+            
+        } else if nowDay - day > 0 && nowHour - hour >= 0 {
             dateDifference = "\(nowDay - day)일 전"
-        } else if nowHour - hour > 0 {
             
+        } else if nowDay - day > 1 && nowHour - hour < 0 {
+            dateDifference = "\(nowDay - day - 1)일 전"
+            
+        } else if nowDay - day < 0 {
+            dateDifference = "\(nowDay - day + 31)일 전"
+            
+        } else if nowHour - hour > 0 && nowMinute - minute >= 0  {
             dateDifference = "\(nowHour - hour)시간 전"
+            
+        } else if nowHour - hour > 1 && nowMinute - minute < 0 {
+            dateDifference = "\(nowHour - hour - 1)시간 전"
+            
+        } else if nowHour - hour < 0 {
+            dateDifference = "\(nowHour - hour + 24)시간 전"
+            
         } else if nowMinute - minute > 0 {
-            
             dateDifference = "\(nowMinute - minute)분 전"
-        } else if (nowMinute - minute) == 0 {
             
-            dateDifference = "1분 전"
+        } else if nowHour - hour == 1 && nowMinute - minute < 0 {
+            dateDifference = "\(nowMinute - minute + 60)분 전"
+            
+        } else if (nowMinute - minute) == 0 {
+            dateDifference = "방금 전"
+            
         }
         
         return dateDifference ?? "오류"
     }
 }
+
+

--- a/Relay/Relay/Scenes/Extension+/Extension+Double.swift
+++ b/Relay/Relay/Scenes/Extension+/Extension+Double.swift
@@ -51,7 +51,7 @@ extension Double {
         } else if nowMonth - month > 1 && nowDay - day < 0 {
             dateDifference = "\(nowMonth - month - 1)달 전"
             
-        } else if nowMonth - month < 0 {
+        } else if nowMonth - month < 0 && nowDay - day >= 0 {
             dateDifference = "\(nowMonth - month + 12)달 전"
             
         } else if nowDay - day > 0 && nowHour - hour >= 0 {


### PR DESCRIPTION
## 작업사항
소설 작성 시간과 현재시간 사이의 시간변환 시 생기는 오류를 수정했습니다.
2022년 12월 31일날 작성시 2023년 1월 1일이 되면 1년전으로 표기되는 오류 -> 하루 전
11월 30일 23시 59분 작성시 12월 1일 0시 1분이 되면 한 달 전으로 표기되는 오류 -> 2분 전

## 이슈번호
- #140

## 특이사항(Optional)
작성 시간과 현재 시간의 차이가 1분 미만일 경우 '방금 전'으로 표시되도록 수정했습니다.

close #140
