### PR TITLE
[2022/02/22] fix/relayMainView/pageAnimation >> RelayMainViewController의 CardView 재생버튼이 애니매이션되면 초기화되는 버그 수정

### DIFF
--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -190,10 +190,12 @@ class RelayMainViewControllerObservable: ObservableObject {
     @Published var pageNumber: Int?
     @Published var nowPlayingPage: Int?
     @Published var playingPlaylistID: Int?
+    @Published var latestPlayinngPage: Int?
     
     var onTouchAction: (() -> Void)!
     
     func playMusic(bgmID: Int) {
+        latestPlayinngPage = bgmID
         playingPlaylistID = bgmID
         
         let playlist = Playlist()
@@ -227,6 +229,7 @@ class RelayMainViewControllerObservable: ObservableObject {
     func resetPlayer() {
         self.pageNumber = nil
         self.nowPlayingPage = nil
+        self.latestPlayinngPage = nil
         self.playingPlaylistID = nil
         self.stopMusic()
     }

--- a/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
+++ b/Relay/Relay/Scenes/MainView/RelayMainViewController.swift
@@ -58,10 +58,7 @@ class RelayMainViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        observable.pageNumber = nil
-        observable.nowPlayingPage = nil
-        observable.playingPlaylistID = nil
-        observable.stopMusic()
+        observable.resetPlayer()
         
         recommend = mockRecommend.recommend
     }
@@ -225,5 +222,12 @@ class RelayMainViewControllerObservable: ObservableObject {
     
     func pauseMusic() {
         audioPlayer?.pause()
+    }
+    
+    func resetPlayer() {
+        self.pageNumber = nil
+        self.nowPlayingPage = nil
+        self.playingPlaylistID = nil
+        self.stopMusic()
     }
 }

--- a/Relay/Relay/Scenes/MainView/Views/CardView.swift
+++ b/Relay/Relay/Scenes/MainView/Views/CardView.swift
@@ -36,11 +36,11 @@ struct CardView: View {
                                 if isPlaying {
                                     if page == observable.nowPlayingPage {
                                         observable.pauseMusic()
+                                        observable.nowPlayingPage = nil
                                         isPlaying = false
                                     } else {
                                         observable.nowPlayingPage = page
                                         observable.playMusic(bgmID: story.bgm)
-                                        isPlaying = true
                                     }
                                 } else {
                                     if page == observable.nowPlayingPage {
@@ -52,7 +52,7 @@ struct CardView: View {
                                     isPlaying = true
                                 }
                             } label: {
-                                Image(systemName: (isPlaying && page == observable.nowPlayingPage) ? "pause.circle" : "play.circle")
+                                Image(systemName: page == observable.nowPlayingPage ? "pause.circle" : "play.circle")
                                     .foregroundColor(.white)
                                     .font(.system(size: 32))
                             }

--- a/Relay/Relay/Scenes/MainView/Views/CardView.swift
+++ b/Relay/Relay/Scenes/MainView/Views/CardView.swift
@@ -40,14 +40,28 @@ struct CardView: View {
                                         isPlaying = false
                                     } else {
                                         observable.nowPlayingPage = page
-                                        observable.playMusic(bgmID: story.bgm)
+                                        
+                                        if observable.latestPlayinngPage != page {
+                                            observable.playMusic(bgmID: story.bgm)
+                                            observable.latestPlayinngPage = page
+                                        } else {
+                                            observable.playMusic()
+                                        }
                                     }
                                 } else {
                                     if page == observable.nowPlayingPage {
-                                        observable.playMusic()
+                                        observable.pauseMusic()
+                                        observable.nowPlayingPage = nil
+                                        isPlaying = false
                                     } else {
                                         observable.nowPlayingPage = page
-                                        observable.playMusic(bgmID: story.bgm)
+                                        
+                                        if observable.latestPlayinngPage != page {
+                                            observable.playMusic(bgmID: story.bgm)
+                                            observable.latestPlayinngPage = page
+                                        } else {
+                                            observable.playMusic()
+                                        }
                                     }
                                     isPlaying = true
                                 }

--- a/Relay/Relay/Scenes/TabBarController.swift
+++ b/Relay/Relay/Scenes/TabBarController.swift
@@ -9,8 +9,12 @@ import UIKit
 import SnapKit
 
 class TabBarController: UITabBarController {
-    private lazy var mainViewController: UIViewController = {
-        let viewController = UINavigationController(rootViewController: RelayMainViewController())
+    private lazy var mainViewController = RelayMainViewController()
+    private lazy var browsingViewController = RelayBrowsingViewController()
+    private lazy var profileViewContorller = RelayProfileViewController()
+    
+    private lazy var mainTap: UIViewController = {
+        let viewController = UINavigationController(rootViewController: mainViewController)
         let image = UIImage(systemName: "flag")?.resize(newWidth: 19.0)
         let selectedImage = UIImage(systemName: "flag.fill")?.resize(newWidth: 19.0)
         let tabBarItem = UITabBarItem(
@@ -27,8 +31,8 @@ class TabBarController: UITabBarController {
         return viewController
     }()
     
-    private lazy var browsingViewController: UIViewController = {
-        let viewController = UINavigationController(rootViewController: RelayBrowsingViewController())
+    private lazy var browsingTap: UIViewController = {
+        let viewController = UINavigationController(rootViewController: browsingViewController)
         let image = UIImage(systemName: "book")?.resize(newWidth: 23.0)
         let selectedImage = UIImage(systemName: "book.fill")?.resize(newWidth: 19.0)
         let tabBarItem = UITabBarItem(
@@ -45,8 +49,8 @@ class TabBarController: UITabBarController {
         return viewController
     }()
     
-    private lazy var profileViewController: UIViewController = {
-        let viewController = UINavigationController(rootViewController: RelayProfileViewController())
+    private lazy var profileTap: UIViewController = {
+        let viewController = UINavigationController(rootViewController: profileViewContorller)
         let image = UIImage(systemName: "person")?.resize(newWidth: 18.0)
         let selectedImage = UIImage(systemName: "person.fill")?.resize(newWidth: 19.0)
         let tabBarItem = UITabBarItem(
@@ -65,6 +69,7 @@ class TabBarController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        tabBarController?.delegate = self
         tabBar.backgroundColor = .systemBackground
         setupTabBar()
     }
@@ -80,12 +85,20 @@ class TabBarController: UITabBarController {
     }
 }
 
+extension TabBarController: UITabBarControllerDelegate {
+    override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
+        if item.tag != 0 {
+            mainViewController.observable.resetPlayer()
+        }
+    }
+}
+
 extension TabBarController {
     private func setupTabBar() {
         viewControllers = [
-            mainViewController,
-            browsingViewController,
-            profileViewController
+            mainTap,
+            browsingTap,
+            profileTap
         ]
         
         let systemFontAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 11.0, weight: .bold)]


### PR DESCRIPTION
## 작업사항
1. RelayMainViewController의 CardView 재생버튼이 애니매이션되면 초기화되는 버그를 수정하였습니다. (084cf47)
2. RelayMainViewController에서 음악을 재생하다 다른탭으로 넘어가도 음악이 재생되던 버그를 수정하였습니다. (ae1c30d)
3. RelayMainViewController에서 소설을 일시정지 한 후 다시 같은 소설을 누를때 처음부터 실행이 아닌 일시정지상태부터 재실행 되도록 수정하였습니다. (b2fa32a)

|버그수정 영상|
|:---:|
|<img width="300" src="https://user-images.githubusercontent.com/83946704/220509953-61d8132c-a14c-47db-a641-94bbfa89a648.gif">|

## 이슈번호
- #148

## 특이사항(Optional)
2번을 구현하기 위해 최상위 컨트롤러인 TabBarController의 delegate 메소드를 오버라이드하여 구현하였습니다.
