### PR TITLE
[2023/03/02] Feat/connectZeroContentsView >> 컨텐츠가 없을 때의 화면 디자인 및 로직 구현

### DIFF
--- a/Relay/Relay.xcodeproj/project.pbxproj
+++ b/Relay/Relay.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		B533AB62291BFB2200B73867 /* RelayTermsAndConditionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B533AB61291BFB2200B73867 /* RelayTermsAndConditionsViewController.swift */; };
 		B533AB64291C107200B73867 /* RelayPrivacyPolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B533AB63291C107200B73867 /* RelayPrivacyPolicyViewController.swift */; };
 		B534447C29AF40BF0064634E /* Extension+UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B534447B29AF40BF0064634E /* Extension+UICollectionView.swift */; };
+		B534447E29AF42640064634E /* Extension+UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B534447D29AF42640064634E /* Extension+UITableView.swift */; };
 		B5687A67292C8B7D0077E3F0 /* RelayOnboardingViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5687A66292C8B7D0077E3F0 /* RelayOnboardingViewCell.swift */; };
 		B5687A69292C8BE40077E3F0 /* RelayOnboardingDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5687A68292C8BE40077E3F0 /* RelayOnboardingDataModel.swift */; };
 		B5C0B4BD290F7C9A00077B5F /* RelayOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C0B4BC290F7C9A00077B5F /* RelayOnboardingViewController.swift */; };
@@ -207,6 +208,7 @@
 		B533AB61291BFB2200B73867 /* RelayTermsAndConditionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayTermsAndConditionsViewController.swift; sourceTree = "<group>"; };
 		B533AB63291C107200B73867 /* RelayPrivacyPolicyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayPrivacyPolicyViewController.swift; sourceTree = "<group>"; };
 		B534447B29AF40BF0064634E /* Extension+UICollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+UICollectionView.swift"; sourceTree = "<group>"; };
+		B534447D29AF42640064634E /* Extension+UITableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+UITableView.swift"; sourceTree = "<group>"; };
 		B5687A66292C8B7D0077E3F0 /* RelayOnboardingViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayOnboardingViewCell.swift; sourceTree = "<group>"; };
 		B5687A68292C8BE40077E3F0 /* RelayOnboardingDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayOnboardingDataModel.swift; sourceTree = "<group>"; };
 		B5C0B4BC290F7C9A00077B5F /* RelayOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayOnboardingViewController.swift; sourceTree = "<group>"; };
@@ -588,6 +590,7 @@
 				32464EB8291B99E400BDAB7C /* Extension+UIViewController.swift */,
 				55D5530A292D3CD80013FF5E /* Extension+Double.swift */,
 				B534447B29AF40BF0064634E /* Extension+UICollectionView.swift */,
+				B534447D29AF42640064634E /* Extension+UITableView.swift */,
 			);
 			path = "Extension+";
 			sourceTree = "<group>";
@@ -829,6 +832,7 @@
 				73741CB1291D367500E7F765 /* RecommendAPI.swift in Sources */,
 				55D55301292BA0480013FF5E /* MockStory.swift in Sources */,
 				55867E1F2914E77100C79FFC /* RelayCategoryViewController.swift in Sources */,
+				B534447E29AF42640064634E /* Extension+UITableView.swift in Sources */,
 				73741CB5291D369C00E7F765 /* AuthPlugin.swift in Sources */,
 				73741CBF291D37AF00E7F765 /* Notice.swift in Sources */,
 				73741CAD291D365B00E7F765 /* UserAPI.swift in Sources */,

--- a/Relay/Relay.xcodeproj/project.pbxproj
+++ b/Relay/Relay.xcodeproj/project.pbxproj
@@ -100,7 +100,7 @@
 		B533AB5E291AC52100B73867 /* RelayDeleteAccountAgreementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B533AB5D291AC52100B73867 /* RelayDeleteAccountAgreementView.swift */; };
 		B533AB62291BFB2200B73867 /* RelayTermsAndConditionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B533AB61291BFB2200B73867 /* RelayTermsAndConditionsViewController.swift */; };
 		B533AB64291C107200B73867 /* RelayPrivacyPolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B533AB63291C107200B73867 /* RelayPrivacyPolicyViewController.swift */; };
-		B53444762980513B0064634E /* RelayListEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53444752980513B0064634E /* RelayListEmptyView.swift */; };
+		B534447C29AF40BF0064634E /* Extension+UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B534447B29AF40BF0064634E /* Extension+UICollectionView.swift */; };
 		B5687A67292C8B7D0077E3F0 /* RelayOnboardingViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5687A66292C8B7D0077E3F0 /* RelayOnboardingViewCell.swift */; };
 		B5687A69292C8BE40077E3F0 /* RelayOnboardingDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5687A68292C8BE40077E3F0 /* RelayOnboardingDataModel.swift */; };
 		B5C0B4BD290F7C9A00077B5F /* RelayOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C0B4BC290F7C9A00077B5F /* RelayOnboardingViewController.swift */; };
@@ -206,7 +206,7 @@
 		B533AB5D291AC52100B73867 /* RelayDeleteAccountAgreementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayDeleteAccountAgreementView.swift; sourceTree = "<group>"; };
 		B533AB61291BFB2200B73867 /* RelayTermsAndConditionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayTermsAndConditionsViewController.swift; sourceTree = "<group>"; };
 		B533AB63291C107200B73867 /* RelayPrivacyPolicyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayPrivacyPolicyViewController.swift; sourceTree = "<group>"; };
-		B53444752980513B0064634E /* RelayListEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayListEmptyView.swift; sourceTree = "<group>"; };
+		B534447B29AF40BF0064634E /* Extension+UICollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+UICollectionView.swift"; sourceTree = "<group>"; };
 		B5687A66292C8B7D0077E3F0 /* RelayOnboardingViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayOnboardingViewCell.swift; sourceTree = "<group>"; };
 		B5687A68292C8BE40077E3F0 /* RelayOnboardingDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayOnboardingDataModel.swift; sourceTree = "<group>"; };
 		B5C0B4BC290F7C9A00077B5F /* RelayOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayOnboardingViewController.swift; sourceTree = "<group>"; };
@@ -562,7 +562,6 @@
 				556F309629102F83005D7AF4 /* RelayListView.swift */,
 				556F309829103676005D7AF4 /* RelayListHeaderView.swift */,
 				556F309A29117E1F005D7AF4 /* RelayListCollectionViewCell.swift */,
-				B53444752980513B0064634E /* RelayListEmptyView.swift */,
 			);
 			path = RelayListView;
 			sourceTree = "<group>";
@@ -588,6 +587,7 @@
 				55867E142912B7DA00C79FFC /* Extension+UIColor.swift */,
 				32464EB8291B99E400BDAB7C /* Extension+UIViewController.swift */,
 				55D5530A292D3CD80013FF5E /* Extension+Double.swift */,
+				B534447B29AF40BF0064634E /* Extension+UICollectionView.swift */,
 			);
 			path = "Extension+";
 			sourceTree = "<group>";
@@ -815,7 +815,6 @@
 				55FDCEB7290ABB0C000AB345 /* RelayUserActivityCollectionViewCell.swift in Sources */,
 				556F309B29117E1F005D7AF4 /* RelayListCollectionViewCell.swift in Sources */,
 				32DA1B7F29123F7500C6FDC1 /* DetailViewController.swift in Sources */,
-				B53444762980513B0064634E /* RelayListEmptyView.swift in Sources */,
 				55D552FF292B9EA20013FF5E /* MockUser.swift in Sources */,
 				55867E1D29142C6700C79FFC /* CategoryModalPresentationController.swift in Sources */,
 				55745F3B291936ED00414462 /* RelayReadingFooterView.swift in Sources */,
@@ -834,6 +833,7 @@
 				73741CBF291D37AF00E7F765 /* Notice.swift in Sources */,
 				73741CAD291D365B00E7F765 /* UserAPI.swift in Sources */,
 				55867E192913AC8D00C79FFC /* RelayBrowsingHeaderView.swift in Sources */,
+				B534447C29AF40BF0064634E /* Extension+UICollectionView.swift in Sources */,
 				73741CB9291D371100E7F765 /* Relay.swift in Sources */,
 				55745FC6291B9B9F00414462 /* RelayReadingFinishFooterView.swift in Sources */,
 				3212D6F82935EF1B0080F3E0 /* MockNotice.swift in Sources */,

--- a/Relay/Relay.xcodeproj/project.pbxproj
+++ b/Relay/Relay.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		B533AB5E291AC52100B73867 /* RelayDeleteAccountAgreementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B533AB5D291AC52100B73867 /* RelayDeleteAccountAgreementView.swift */; };
 		B533AB62291BFB2200B73867 /* RelayTermsAndConditionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B533AB61291BFB2200B73867 /* RelayTermsAndConditionsViewController.swift */; };
 		B533AB64291C107200B73867 /* RelayPrivacyPolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B533AB63291C107200B73867 /* RelayPrivacyPolicyViewController.swift */; };
+		B53444762980513B0064634E /* RelayListEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53444752980513B0064634E /* RelayListEmptyView.swift */; };
 		B5687A67292C8B7D0077E3F0 /* RelayOnboardingViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5687A66292C8B7D0077E3F0 /* RelayOnboardingViewCell.swift */; };
 		B5687A69292C8BE40077E3F0 /* RelayOnboardingDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5687A68292C8BE40077E3F0 /* RelayOnboardingDataModel.swift */; };
 		B5C0B4BD290F7C9A00077B5F /* RelayOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C0B4BC290F7C9A00077B5F /* RelayOnboardingViewController.swift */; };
@@ -205,6 +206,7 @@
 		B533AB5D291AC52100B73867 /* RelayDeleteAccountAgreementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayDeleteAccountAgreementView.swift; sourceTree = "<group>"; };
 		B533AB61291BFB2200B73867 /* RelayTermsAndConditionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayTermsAndConditionsViewController.swift; sourceTree = "<group>"; };
 		B533AB63291C107200B73867 /* RelayPrivacyPolicyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayPrivacyPolicyViewController.swift; sourceTree = "<group>"; };
+		B53444752980513B0064634E /* RelayListEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayListEmptyView.swift; sourceTree = "<group>"; };
 		B5687A66292C8B7D0077E3F0 /* RelayOnboardingViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayOnboardingViewCell.swift; sourceTree = "<group>"; };
 		B5687A68292C8BE40077E3F0 /* RelayOnboardingDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayOnboardingDataModel.swift; sourceTree = "<group>"; };
 		B5C0B4BC290F7C9A00077B5F /* RelayOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayOnboardingViewController.swift; sourceTree = "<group>"; };
@@ -560,6 +562,7 @@
 				556F309629102F83005D7AF4 /* RelayListView.swift */,
 				556F309829103676005D7AF4 /* RelayListHeaderView.swift */,
 				556F309A29117E1F005D7AF4 /* RelayListCollectionViewCell.swift */,
+				B53444752980513B0064634E /* RelayListEmptyView.swift */,
 			);
 			path = RelayListView;
 			sourceTree = "<group>";
@@ -812,6 +815,7 @@
 				55FDCEB7290ABB0C000AB345 /* RelayUserActivityCollectionViewCell.swift in Sources */,
 				556F309B29117E1F005D7AF4 /* RelayListCollectionViewCell.swift in Sources */,
 				32DA1B7F29123F7500C6FDC1 /* DetailViewController.swift in Sources */,
+				B53444762980513B0064634E /* RelayListEmptyView.swift in Sources */,
 				55D552FF292B9EA20013FF5E /* MockUser.swift in Sources */,
 				55867E1D29142C6700C79FFC /* CategoryModalPresentationController.swift in Sources */,
 				55745F3B291936ED00414462 /* RelayReadingFooterView.swift in Sources */,

--- a/Relay/Relay/Scenes/ActivityView/RelayActivityViewController.swift
+++ b/Relay/Relay/Scenes/ActivityView/RelayActivityViewController.swift
@@ -99,7 +99,22 @@ extension RelayActivityViewController: UICollectionViewDelegateFlowLayout {
 
 extension RelayActivityViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        stories.count
+        if stories.count == 0 {
+            switch type {
+            case .like:
+                collectionView.setEmptyView(message: "좋아요한 릴레이가 없습니다.")
+            case .participated:
+                collectionView.setEmptyView(message: "참여한 릴레이가 없습니다.")
+            case .started:
+                collectionView.setEmptyView(message: "시작한 릴레이가 없습니다.")
+            default:
+                collectionView.setEmptyView(message: "디폴트.")
+            }
+        }
+        else {
+            collectionView.restore()
+        }
+        return stories.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
+++ b/Relay/Relay/Scenes/BrowsingView/RelayBrowsingViewController.swift
@@ -166,7 +166,13 @@ extension RelayBrowsingViewController: UICollectionViewDelegateFlowLayout {
 
 extension RelayBrowsingViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        stories.count
+        if stories.count == 0 {
+            collectionView.setEmptyView(message: "현재 시작된 릴레이가 없습니다.")
+        }
+        else {
+            collectionView.restore()
+        }
+        return stories.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/Relay/Relay/Scenes/Extension+/Extension+UICollectionView.swift
+++ b/Relay/Relay/Scenes/Extension+/Extension+UICollectionView.swift
@@ -13,18 +13,16 @@ extension UICollectionView {
     func setEmptyView(message: String) {
         let emptyView: UIView = {
             let view = UIView(frame: CGRect(x: self.center.x, y: self.center.y, width: self.bounds.width, height: self.bounds.height))
-            view.backgroundColor = .blue
             
             return view
         }()
         
-        var emptyViewImage: UIImageView {
+        let emptyViewImage: UIImageView = {
             let image = UIImageView()
             image.image = UIImage(systemName: "tray")?.resize(newWidth: 30.0).imageWithColor(color: .relayPink1)
-            image.sizeToFit()
             
             return image
-        }
+        }()
         
         let emptyViewLabel: UILabel = {
             let label = UILabel()
@@ -40,14 +38,12 @@ extension UICollectionView {
         
         emptyViewImage.snp.makeConstraints {
             $0.centerX.equalTo(emptyView.snp.centerX)
-            $0.centerY.equalTo(emptyView.snp.centerY)
-//            $0.bottom.equalTo(emptyViewLabel.snp.top).offset(30)
+            $0.bottom.equalTo(emptyViewLabel.snp.top).offset(-10)
         }
-//        emptyViewLabel.snp.makeConstraints {
-//            $0.centerX.equalTo(emptyView.snp.centerX)
-//            $0.centerY.equalTo(emptyView.snp.centerY)
-////            $0.top.equalTo(emptyViewImage.snp.bottom).offset(30)
-//        }
+        emptyViewLabel.snp.makeConstraints {
+            $0.centerX.equalTo(emptyView.snp.centerX)
+            $0.centerY.equalTo(emptyView.snp.centerY)
+        }
         
         self.backgroundView = emptyView
         

--- a/Relay/Relay/Scenes/Extension+/Extension+UICollectionView.swift
+++ b/Relay/Relay/Scenes/Extension+/Extension+UICollectionView.swift
@@ -1,8 +1,8 @@
 //
-//  RelayListEmptyView.swift
+//  Extension+UICollectionView.swift
 //  Relay
 //
-//  Created by seungyeon oh on 2023/01/25.
+//  Created by seungyeon oh on 2023/02/28.
 //
 
 import UIKit

--- a/Relay/Relay/Scenes/Extension+/Extension+UITableView.swift
+++ b/Relay/Relay/Scenes/Extension+/Extension+UITableView.swift
@@ -1,0 +1,55 @@
+//
+//  Extension+UITableView.swift
+//  Relay
+//
+//  Created by seungyeon oh on 2023/03/01.
+//
+
+import UIKit
+import SnapKit
+
+extension UITableView {
+    
+    func setEmptyView(message: String) {
+        let emptyView: UIView = {
+            let view = UIView(frame: CGRect(x: self.center.x, y: self.center.y, width: self.bounds.width, height: self.bounds.height))
+            
+            return view
+        }()
+        
+        let emptyViewImage: UIImageView = {
+            let image = UIImageView()
+            image.image = UIImage(systemName: "tray")?.resize(newWidth: 30.0).imageWithColor(color: .relayPink1)
+            
+            return image
+        }()
+        
+        let emptyViewLabel: UILabel = {
+            let label = UILabel()
+            label.text = message
+            label.setFont(.body1)
+            label.textColor = .relayGray
+            
+            return label
+        }()
+        
+        emptyView.addSubview(emptyViewImage)
+        emptyView.addSubview(emptyViewLabel)
+        
+        emptyViewImage.snp.makeConstraints {
+            $0.centerX.equalTo(emptyView.snp.centerX)
+            $0.bottom.equalTo(emptyViewLabel.snp.top).offset(-10)
+        }
+        emptyViewLabel.snp.makeConstraints {
+            $0.centerX.equalTo(emptyView.snp.centerX)
+            $0.centerY.equalTo(emptyView.snp.centerY)
+        }
+        
+        self.backgroundView = emptyView
+        
+    }
+    
+    func restore() {
+        self.backgroundView = nil
+    }
+}

--- a/Relay/Relay/Scenes/NoticeView/RelayNoticeViewController.swift
+++ b/Relay/Relay/Scenes/NoticeView/RelayNoticeViewController.swift
@@ -89,7 +89,7 @@ extension RelayNoticeViewController: UITableViewDelegate, UITableViewDataSource 
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if let noticeArray = noticeArray {
-            if noticeArray.count == 0 {
+            if noticeArray.isEmpty {
                 tableView.setEmptyView(message: "받은 알림이 없습니다.")
             }
             return noticeArray.count

--- a/Relay/Relay/Scenes/NoticeView/RelayNoticeViewController.swift
+++ b/Relay/Relay/Scenes/NoticeView/RelayNoticeViewController.swift
@@ -115,10 +115,6 @@ extension RelayNoticeViewController: UITableViewDelegate, UITableViewDataSource 
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if noticeArray != nil {
             return 98
-        } else {
-            return 0
-        }
     }
 }

--- a/Relay/Relay/Scenes/NoticeView/RelayNoticeViewController.swift
+++ b/Relay/Relay/Scenes/NoticeView/RelayNoticeViewController.swift
@@ -89,9 +89,11 @@ extension RelayNoticeViewController: UITableViewDelegate, UITableViewDataSource 
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if let noticeArray = noticeArray {
+            if noticeArray.count == 0 {
+                tableView.setEmptyView(message: "받은 알림이 없습니다.")
+            }
             return noticeArray.count
         } else {
-            //TODO: 알림(noticeArray)이 없을 경우 보여줄 뷰 구현 필요
             return 0
         }
     }
@@ -107,14 +109,16 @@ extension RelayNoticeViewController: UITableViewDelegate, UITableViewDataSource 
         
         if let notice = noticeArray?[indexPath.row] {
             cell.configure(notice)
-        } else {
-            //TODO: 알림(noticeArray)이 없을 경우 보여줄 뷰 구현 필요
         }
         
         return cell
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 98
+        if noticeArray != nil {
+            return 98
+        } else {
+            return 0
+        }
     }
 }

--- a/Relay/Relay/Scenes/Reusable/RelayListView/RelayListEmptyView.swift
+++ b/Relay/Relay/Scenes/Reusable/RelayListView/RelayListEmptyView.swift
@@ -10,6 +10,13 @@ import SnapKit
 
 class RelayListEmptyView: UIView {
     
+    private var emptyViewImage: UIImageView {
+        let image = UIImageView()
+        image.image = UIImage(systemName: "tray")
+        image.tintColor = .relayPink1
+        
+        return image
+    }
   
     init(frame: CGRect, type: ListViewType) {
         super.init(frame: frame)

--- a/Relay/Relay/Scenes/Reusable/RelayListView/RelayListEmptyView.swift
+++ b/Relay/Relay/Scenes/Reusable/RelayListView/RelayListEmptyView.swift
@@ -17,7 +17,16 @@ class RelayListEmptyView: UIView {
         
         return image
     }
-  
+    private lazy var emptyViewLabel: UILabel = {
+        let label = UILabel()
+        
+        label.text = "현재 시작된 릴레이가 없습니다."
+        label.setFont(.body1)
+        label.textColor = .relayGray
+        
+        return label
+    }()
+    
     init(frame: CGRect, type: ListViewType) {
         super.init(frame: frame)
         

--- a/Relay/Relay/Scenes/Reusable/RelayListView/RelayListEmptyView.swift
+++ b/Relay/Relay/Scenes/Reusable/RelayListView/RelayListEmptyView.swift
@@ -30,7 +30,7 @@ class RelayListEmptyView: UIView {
     init(frame: CGRect, type: ListViewType) {
         super.init(frame: frame)
         
-
+        setupLayout()
     }
     
     required init?(coder: NSCoder) {
@@ -38,3 +38,21 @@ class RelayListEmptyView: UIView {
     }
 }
 
+extension RelayListEmptyView{
+    private func setupLayout() {
+        [
+            emptyViewImage,
+            emptyViewLabel
+            
+        ].forEach { addSubview($0) }
+        
+        emptyViewImage.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(emptyViewLabel.snp.top).offset(30)
+        }
+        emptyViewLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
+    }
+}

--- a/Relay/Relay/Scenes/Reusable/RelayListView/RelayListEmptyView.swift
+++ b/Relay/Relay/Scenes/Reusable/RelayListView/RelayListEmptyView.swift
@@ -1,0 +1,24 @@
+//
+//  RelayListEmptyView.swift
+//  Relay
+//
+//  Created by seungyeon oh on 2023/01/25.
+//
+
+import UIKit
+import SnapKit
+
+class RelayListEmptyView: UIView {
+    
+  
+    init(frame: CGRect, type: ListViewType) {
+        super.init(frame: frame)
+        
+
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+


### PR DESCRIPTION
## 작업사항
**Issue : Feature**
<p align="left">
<img src="https://user-images.githubusercontent.com/70955060/222350967-47ddd573-de1d-47ac-9864-c1345764d849.png" width="15%" height="20%">
<img src="https://user-images.githubusercontent.com/70955060/222351062-f12045a8-e9c1-4f02-890a-9cde43936f2d.png" width="15%" height="20%">
<img src="https://user-images.githubusercontent.com/70955060/222351128-dfcd383f-de22-418a-8ec7-4ee3862ff837.png" width="15%" height="20%">
<img src="https://user-images.githubusercontent.com/70955060/222351177-6ed08443-6c3c-4df1-89f7-dc07bb8d5bd5.png" width="15%" height="20%">
<img src="https://user-images.githubusercontent.com/70955060/222351233-7e023faf-7ab7-4fe0-87a2-d91ab6c94baa.png" width="15%" height="20%">
</p>

알림상세뷰, 둘러보기뷰, 마이페이지(시작한, 참여한, 좋아요한 릴레이) 각각의 뷰에 콘텐츠가 없을 때의 디자인 및 로직을 구현했습니다.

## 이슈번호
- #146

## 특이사항(Optional)


close #146 