### PR TITLE
[2023/03/02] Feat/connectLocalAlarmSetting >> RelaySettingViewController의 알림설정과 로컬디바이스 앱설정화면 연결

### DIFF
--- a/Relay/Relay/Scenes/SettingView/RelaySettingViewController.swift
+++ b/Relay/Relay/Scenes/SettingView/RelaySettingViewController.swift
@@ -47,7 +47,7 @@ class RelaySettingViewController: UIViewController, UITableViewDelegate, UITable
                 self.toMyInfoView()
             },
             SettingsOption(title: "알림 설정", details: "", version: "") {
-                //추후 로컬 디바이스 알림설정과 연결
+                UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
             }
         ]))
         models.append(Section(title: "", details: "", version: "", options: [


### PR DESCRIPTION
## 작업사항
알림설정버튼을 누를 시 로컬디바이스 앱알림설정화면과 연결되도록 해주었습니다.

## 이슈번호
- #152

## 특이사항(Optional)

close #152 
